### PR TITLE
webhook通知支持 通知主题 及 通知内容替换

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /data/
 /logs/
 .idea
+**/.history/
+/allinssl

--- a/backend/internal/report/webhook.go
+++ b/backend/internal/report/webhook.go
@@ -191,7 +191,7 @@ func NotifyWebHook(params map[string]any) error {
 			subjStr = strings.ReplaceAll(subjStr, `"`, `\"`)
 			bodyStr = strings.ReplaceAll(bodyStr, `"`, `\"`)
 			if strings.Contains(config.Data, "{subject}") {
-				config.Data = strings.ReplaceAll(config.Data, "{subject}", subjStr+"\n")
+				config.Data = strings.ReplaceAll(config.Data, "{subject}", subjStr)
 			}
 			if strings.Contains(config.Data, "{body}") {
 				config.Data = strings.ReplaceAll(config.Data, "{body}", bodyStr)

--- a/backend/internal/report/webhook.go
+++ b/backend/internal/report/webhook.go
@@ -33,11 +33,11 @@ func NewWebHookReporter(config *ReportConfig, logger *public.Logger) *WebHookRep
 	if config.IgnoreSSL {
 		client.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
 	}
-	
+
 	if config.Data == "" {
 		config.Data = "{}" // 默认数据为空JSON对象
 	}
-	
+
 	return &WebHookReporter{
 		config:     config,
 		logger:     logger,
@@ -184,6 +184,22 @@ func NotifyWebHook(params map[string]any) error {
 		return fmt.Errorf("解析配置失败: %v", err)
 	}
 	
+	if params["subject"] != nil && params["body"] != nil {
+		subjStr, ok1 := params["subject"].(string)
+		bodyStr, ok2 := params["body"].(string)
+		if ok1 && ok2 {
+			subjStr = strings.ReplaceAll(subjStr, `"`, `\"`)
+			bodyStr = strings.ReplaceAll(bodyStr, `"`, `\"`)
+			if strings.Contains(config.Data, "{subject}") {
+				config.Data = strings.ReplaceAll(config.Data, "{subject}", subjStr+"\n")
+			}
+			if strings.Contains(config.Data, "{body}") {
+				config.Data = strings.ReplaceAll(config.Data, "{body}", bodyStr)
+			}
+			config.Data = strings.ReplaceAll(config.Data, "\n", `\n`)
+		}
+	}
+
 	reporter := NewWebHookReporter(&config, logger)
 	httpctx := context.Background()
 	err = reporter.Send(httpctx)

--- a/backend/internal/report/webhook.go
+++ b/backend/internal/report/webhook.go
@@ -207,8 +207,8 @@ func NotifyWebHook(params map[string]any) error {
 	config.Data = strings.ReplaceAll(config.Data, "\n", `\n`)
 
 	if !json.Valid([]byte(config.Data)) {
-        return fmt.Errorf("通知主题或通知内容包含特殊字符，消息配置字段替换失败")
-    }
+		return fmt.Errorf("通知主题或通知内容包含特殊字符，消息配置字段替换失败")
+	}
 
 	reporter := NewWebHookReporter(&config, logger)
 	httpctx := context.Background()

--- a/backend/internal/report/webhook.go
+++ b/backend/internal/report/webhook.go
@@ -183,22 +183,32 @@ func NotifyWebHook(params map[string]any) error {
 	if err != nil {
 		return fmt.Errorf("解析配置失败: %v", err)
 	}
-	
-	if params["subject"] != nil && params["body"] != nil {
-		subjStr, ok1 := params["subject"].(string)
-		bodyStr, ok2 := params["body"].(string)
-		if ok1 && ok2 {
-			subjStr = strings.ReplaceAll(subjStr, `"`, `\"`)
-			bodyStr = strings.ReplaceAll(bodyStr, `"`, `\"`)
-			if strings.Contains(config.Data, "{subject}") {
-				config.Data = strings.ReplaceAll(config.Data, "{subject}", subjStr)
-			}
-			if strings.Contains(config.Data, "{body}") {
-				config.Data = strings.ReplaceAll(config.Data, "{body}", bodyStr)
-			}
-			config.Data = strings.ReplaceAll(config.Data, "\n", `\n`)
+
+	escapeStr := func(s string) string {
+	    b, _ := json.Marshal(s)
+		if len(b) >= 2 {
+			return string(b[1 : len(b)-1])
+		}
+	    return ""
+	}
+
+	if subjectVal, exists := params["subject"]; exists && subjectVal != nil {
+		if subjStr, ok := subjectVal.(string); ok && len(subjStr) > 0 {
+			config.Data = strings.ReplaceAll(config.Data, "{subject}", escapeStr(subjStr))
 		}
 	}
+
+	if bodyVal, exists := params["body"]; exists && bodyVal != nil {
+		if bodyStr, ok := bodyVal.(string); ok && len(bodyStr) > 0 {
+			config.Data = strings.ReplaceAll(config.Data, "{body}", escapeStr(bodyStr))
+		}
+	}
+
+	config.Data = strings.ReplaceAll(config.Data, "\n", `\n`)
+
+	if !json.Valid([]byte(config.Data)) {
+        return fmt.Errorf("通知主题或通知内容包含特殊字符，消息配置字段替换失败")
+    }
 
 	reporter := NewWebHookReporter(&config, logger)
 	httpctx := context.Background()


### PR DESCRIPTION
现有 webhook中对消息配置中的消息标题及消息内容未体现 #184 
<img width="612" alt="image" src="https://github.com/user-attachments/assets/409d88ce-442b-430c-8ae5-aafbfcf81d07" />



本次修改将替换 **WebHook通知** 中  **WebHook推送通知回调数据（可选）** 正文部分内容，查找 `{subject}` 及 `{body}` 替换为  对应的 `通知主题` 及 `通知内容`, 并替换二者中的物理换行为 \n, 如下图所示

<img width="673" alt="image" src="https://github.com/user-attachments/assets/777cb190-89a2-462f-9774-129ab5e41750" />

如上图所示， 实际发送消息将为
```json
{"subject":"*通知主题*","body":"----------------\n网站证书*部署成功*"}
```

