### PR TITLE
【新增】导出fullchain并统一部署证书链

### DIFF
--- a/backend/app/api/cert.go
+++ b/backend/app/api/cert.go
@@ -94,6 +94,10 @@ func DownloadCert(c *gin.Context) {
 		public.FailMsg(c, err.Error())
 		return
 	}
+	issuerCert := ""
+	if v, ok := certData["issuer_cert"]; ok {
+		issuerCert = v
+	}
 
 	// 构建 zip 包（内存中）
 	buf := new(bytes.Buffer)
@@ -111,6 +115,17 @@ func DownloadCert(c *gin.Context) {
 		public.FailMsg(c, err.Error())
 		return
 	}
+	// fullchain.pem
+	fullchain := public.BuildFullChain(certStr, issuerCert)
+	fullchainWriter, err := zipWriter.Create("Nginx/fullchain.pem")
+	if err != nil {
+		public.FailMsg(c, err.Error())
+		return
+	}
+	if _, err := fullchainWriter.Write([]byte(fullchain)); err != nil {
+		public.FailMsg(c, err.Error())
+		return
+	}
 	// key.pem
 	keyStr := certData["key"]
 	keyWriter, err := zipWriter.Create("Nginx/key.pem")
@@ -124,7 +139,7 @@ func DownloadCert(c *gin.Context) {
 	}
 	// cert.pfx
 	pfxPassword := "allinssl"
-	pfxData, err := public.PEMToPFX(certStr, keyStr, pfxPassword)
+	pfxData, err := public.PEMToPFX(fullchain, keyStr, pfxPassword)
 	if err == nil && len(pfxData) > 0 {
 		pfxWriter, err := zipWriter.Create("IIS/cert.pfx")
 		if err != nil {

--- a/backend/app/api/private_ca/private_ca.go
+++ b/backend/app/api/private_ca/private_ca.go
@@ -166,6 +166,27 @@ func DownloadCert(c *gin.Context) {
 		public.FailMsg(c, "证书不存在")
 		return
 	}
+	issuerCert := ""
+	if form.Type == "leaf" {
+		if caID, ok := certData["ca_id"]; ok && caID != nil {
+			var caIdInt64 int64
+			switch v := caID.(type) {
+			case int64:
+				caIdInt64 = v
+			case int:
+				caIdInt64 = int64(v)
+			case float64:
+				caIdInt64 = int64(v)
+			}
+			if caIdInt64 > 0 {
+				if issuerData, err := private_ca.GetCert(caIdInt64, "ca"); err == nil {
+					if issuer, ok := issuerData["cert"].(string); ok {
+						issuerCert = issuer
+					}
+				}
+			}
+		}
+	}
 
 	// 构建 zip 包（内存中）
 	buf := new(bytes.Buffer)
@@ -189,6 +210,17 @@ func DownloadCert(c *gin.Context) {
 		return
 	}
 	if _, err := keyWriter.Write([]byte(keyStr)); err != nil {
+		public.FailMsg(c, err.Error())
+		return
+	}
+	// fullchain.pem
+	fullchain := public.BuildFullChain(certStr, issuerCert)
+	fullchainWriter, err := zipWriter.Create("fullchain.pem")
+	if err != nil {
+		public.FailMsg(c, err.Error())
+		return
+	}
+	if _, err := fullchainWriter.Write([]byte(fullchain)); err != nil {
 		public.FailMsg(c, err.Error())
 		return
 	}
@@ -220,7 +252,7 @@ func DownloadCert(c *gin.Context) {
 	if certData["algorithm"] == "ecdsa" || certData["algorithm"] == "rsa" {
 		// cert.pfx
 		pfxPassword := "allinssl"
-		pfxData, err := public.PEMToPFX(certStr, keyStr, pfxPassword)
+		pfxData, err := public.PEMToPFX(fullchain, keyStr, pfxPassword)
 		if err == nil && len(pfxData) > 0 {
 			pfxWriter, err := zipWriter.Create("IIS/cert.pfx")
 			if err != nil {

--- a/backend/internal/cert/cert.go
+++ b/backend/internal/cert/cert.go
@@ -218,6 +218,11 @@ func GetCert(id string) (map[string]string, error) {
 		"cert":    res[0]["cert"].(string),
 		"key":     res[0]["key"].(string),
 	}
+	if res[0]["issuer_cert"] != nil {
+		if issuer, ok := res[0]["issuer_cert"].(string); ok {
+			data["issuer_cert"] = issuer
+		}
+	}
 
 	return data, nil
 }

--- a/backend/internal/private_ca/private_ca.go
+++ b/backend/internal/private_ca/private_ca.go
@@ -202,6 +202,13 @@ func CreateLeafCert(caId, usage, keyBits, validDays int64, cn, san string) (*Lea
 	// 保存到数据库
 	leafObj.SAN = san
 	leafObj.CaId = caId
+	if issuer != nil {
+		if certVal, ok := issuer["cert"]; ok {
+			if certStr, ok := certVal.(string); ok {
+				leafObj.IssuerCert = certStr
+			}
+		}
+	}
 	insertData := public.StructToMap(leafObj, true)
 	_, err = s.Insert(insertData)
 	if err != nil {
@@ -406,6 +413,7 @@ func WorkflowCreateLeafCert(params map[string]any, logger *public.Logger) (map[s
 					certificate = map[string]any{
 						"cert": v["cert"],
 						"key":  v["key"],
+						"issuerCert": issuer["cert"],
 						"skip": true,
 					}
 					break
@@ -421,6 +429,7 @@ func WorkflowCreateLeafCert(params map[string]any, logger *public.Logger) (map[s
 		certificate = map[string]any{
 			"cert": leaf.Cert,
 			"key":  leaf.Key,
+			"issuerCert": leaf.IssuerCert,
 		}
 	}
 

--- a/backend/internal/private_ca/types.go
+++ b/backend/internal/private_ca/types.go
@@ -79,6 +79,7 @@ type LeafCertConfig struct {
 	Usage      int64  `json:"usage" form:"usage"`
 	Cert       string `json:"cert" form:"cert"`
 	Key        string `json:"key" form:"key"`
+	IssuerCert string `json:"-" form:"-"`
 	EnCert     string `json:"en_cert" form:"en_cert"`
 	EnKey      string `json:"en_key" form:"en_key"`
 	Algorithm  string `json:"algorithm" form:"algorithm"`

--- a/backend/internal/workflow/executor.go
+++ b/backend/internal/workflow/executor.go
@@ -77,11 +77,26 @@ func deploy(params map[string]any) (any, error) {
 		logger.Info("=============部署失败=============")
 		return nil, errors.New("证书不存在")
 	}
+	issuerCert := ""
+	if v, ok := certificateMap["issuerCert"]; ok && v != nil {
+		if s, ok := v.(string); ok {
+			issuerCert = s
+		}
+	} else if v, ok := certificateMap["issuer_cert"]; ok && v != nil {
+		if s, ok := v.(string); ok {
+			issuerCert = s
+		}
+	}
 	certStr, ok := certificateMap["cert"].(string)
 	if !ok {
 		logger.Error("证书格式错误")
 		logger.Info("=============部署失败=============")
 		return nil, errors.New("证书格式错误")
+	}
+	if issuerCert != "" {
+		certificateMap["leaf_cert"] = certStr
+		certificateMap["cert"] = public.BuildFullChain(certStr, issuerCert)
+		certStr = certificateMap["cert"].(string)
 	}
 	nowSha256, err := public.GetSHA256(certStr)
 	if err != nil {

--- a/backend/public/cert.go
+++ b/backend/public/cert.go
@@ -13,10 +13,11 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"github.com/pavlo-v-chernykh/keystore-go/v4"
-	"software.sslmate.com/src/go-pkcs12"
 	"strings"
 	"time"
+
+	"github.com/pavlo-v-chernykh/keystore-go/v4"
+	"software.sslmate.com/src/go-pkcs12"
 )
 
 // **解析 PEM 格式的证书**
@@ -46,6 +47,19 @@ func ParsePrivateKey(keyPEM []byte) (crypto.PrivateKey, error) {
 		return key, nil
 	}
 	return nil, fmt.Errorf("无法识别的私钥格式")
+}
+
+// BuildFullChain 拼接叶子证书和中间证书（不包含根证书）
+func BuildFullChain(certPEM, issuerPEM string) string {
+	cert := strings.TrimSpace(certPEM)
+	issuer := strings.TrimSpace(issuerPEM)
+	if cert == "" {
+		return ""
+	}
+	if issuer == "" {
+		return cert
+	}
+	return cert + "\n" + issuer + "\n"
 }
 
 // **检查证书是否过期**

--- a/backend/public/utils.go
+++ b/backend/public/utils.go
@@ -256,6 +256,13 @@ func StructToMap(obj interface{}, ignoreZero bool) map[string]interface{} {
 
 		// 获取 json tag，若为空则用字段名
 		tag := field.Tag.Get("json")
+		if tag != "" {
+			// 去掉 json tag 里的选项，比如 "name,omitempty"
+			tag = strings.Split(tag, ",")[0]
+			if tag == "-" {
+				continue
+			}
+		}
 		if tag == "" {
 			tag = field.Name
 		}


### PR DESCRIPTION
此前导出/部署「私有证书」只给叶子证书，缺少中间 CA，导致链不完整。现已新增并输出 fullchain（叶子+中间），导出包与部署流程统一使用，PFX 也基于 fullchain 生成，同时保留 cert.pem 兼容旧流程。