### PR TITLE
【新增】阿里云CDN/DCDN和七牛云CDN/OSS支持多域名一次部署

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,31 @@ docker run -itd \
 7. 更多命令行操作请参考 [命令行操作](#💻-命令行操作)
 
 ### 源码编译安装
-如需自行编译，请确保已安装Go 1.23+环境：
+如需自行编译，请确保已安装 Go 1.23+ 和 Node.js 18+ 环境：
+
+#### 1. 克隆仓库
 ```bash
 git clone https://github.com/allinssl/allinssl.git
 cd allinssl
+```
+
+#### 2. 构建前端资源
+```bash
+cd frontend
+npm install -g pnpm   # 如未安装 pnpm
+pnpm install
+pnpm run build
+cd ..
+```
+
+> 构建完成后，将 `frontend/apps/allin-ssl/dist/` 下的内容复制到项目根目录的 `static/build/`，后端通过 Go embed 将其打包进二进制。
+```bash
+rm -rf static/build/static/css static/build/static/js
+cp -r frontend/apps/allin-ssl/dist/. static/build
+```
+
+#### 3. 编译后端并启动
+```bash
 go mod tidy
 go build -o allinssl cmd/main.go
 ./allinssl start

--- a/README_EN.md
+++ b/README_EN.md
@@ -31,13 +31,36 @@ ALLinSSL is a comprehensive SSL certificate lifecycle management tool that integ
 ### Installation Steps
 #### 1. Install via official installation script
 #### 2. Compile and install:
-  - When compiling and installing, pay attention to the name and path of the executable file. In `allinssl.sh`, you need to modify the corresponding name and path, otherwise the script may not work
-  - Recommended installation path is `/www/allinssl/`, executable file name should be `allinssl`, and it's recommended to create a symbolic link of `allinssl.sh` to the `/usr/bin/` directory
-  - Installation:
-    1. Download the latest release package and extract it
-    2. Compile the Go program (allinssl)
-    3. Run the executable to start the service
-       - Linux: Execute `./allinssl start`
+
+Make sure Go 1.23+ and Node.js 18+ are installed.
+
+**Step 1: Clone the repository**
+```bash
+git clone https://github.com/allinssl/allinssl.git
+cd allinssl
+```
+
+**Step 2: Build frontend assets**
+```bash
+cd frontend
+npm install -g pnpm   # if pnpm is not installed
+pnpm install
+pnpm run build
+cd ..
+```
+
+> After building, copy the output to `static/build/` so Go can embed it into the binary:
+```bash
+rm -rf static/build/static/css static/build/static/js
+cp -r frontend/apps/allin-ssl/dist/. static/build
+```
+
+**Step 3: Compile and start**
+```bash
+go mod tidy
+go build -o allinssl cmd/main.go
+./allinssl start
+```
 
 ### First-time Setup
 

--- a/backend/internal/cert/deploy/aliyun.go
+++ b/backend/internal/cert/deploy/aliyun.go
@@ -77,15 +77,25 @@ func DeployAliCdn(cfg map[string]any) error {
 		return fmt.Errorf("证书错误：cert")
 	}
 
-	setCdnDomainSSLCertificateRequest := &aliyuncdn.SetCdnDomainSSLCertificateRequest{
-		DomainName:  tea.String(domain),
-		SSLProtocol: tea.String("on"),
-		SSLPub:      tea.String(strings.TrimSpace(certPem)),
-		SSLPri:      tea.String(strings.TrimSpace(keyPem)),
+	deployed := 0
+	for _, d := range strings.Split(domain, ",") {
+		d = strings.TrimSpace(d)
+		if d == "" {
+			continue
+		}
+		setCdnDomainSSLCertificateRequest := &aliyuncdn.SetCdnDomainSSLCertificateRequest{
+			DomainName:  tea.String(d),
+			SSLProtocol: tea.String("on"),
+			SSLPub:      tea.String(strings.TrimSpace(certPem)),
+			SSLPri:      tea.String(strings.TrimSpace(keyPem)),
+		}
+		if _, err = client.SetCdnDomainSSLCertificate(setCdnDomainSSLCertificateRequest); err != nil {
+			return err
+		}
+		deployed++
 	}
-	_, err = client.SetCdnDomainSSLCertificate(setCdnDomainSSLCertificateRequest)
-	if err != nil {
-		return err
+	if deployed == 0 {
+		return fmt.Errorf("参数错误：domain")
 	}
 	return nil
 }

--- a/backend/internal/cert/deploy/aliyun/dcdn.go
+++ b/backend/internal/cert/deploy/aliyun/dcdn.go
@@ -4,6 +4,7 @@ import (
 	"ALLinSSL/backend/internal/access"
 	"encoding/json"
 	"fmt"
+	"strings"
 	openapi "github.com/alibabacloud-go/darabonba-openapi/v2/client"
 	dcdn "github.com/alibabacloud-go/dcdn-20180115/v3/client"
 	util "github.com/alibabacloud-go/tea-utils/v2/service"
@@ -84,9 +85,19 @@ func DeployAliyunDcdn(cfg map[string]any) error {
 	if !ok {
 		return fmt.Errorf("域名不存在或格式错误")
 	}
-	err = DeployCertToDcdn(client, domain, certPEM, privkeyPEM)
-	if err != nil {
-		return fmt.Errorf("部署证书到 DCDN 失败: %w", err)
+	deployed := 0
+	for _, d := range strings.Split(domain, ",") {
+		d = strings.TrimSpace(d)
+		if d == "" {
+			continue
+		}
+		if err = DeployCertToDcdn(client, d, certPEM, privkeyPEM); err != nil {
+			return fmt.Errorf("部署证书到 DCDN 失败: %w", err)
+		}
+		deployed++
+	}
+	if deployed == 0 {
+		return fmt.Errorf("域名不存在或格式错误")
 	}
 	return nil
 }

--- a/backend/internal/cert/deploy/qiniu.go
+++ b/backend/internal/cert/deploy/qiniu.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/qiniu/go-sdk/v7/auth"
 	"github.com/qiniu/go-sdk/v7/client"
@@ -66,13 +67,26 @@ func DeployQiniuCdn(cfg map[string]any) error {
 	if err != nil {
 		return err
 	}
-	path := fmt.Sprintf("domain/%v/sslize", domain)
-	m := map[string]any{
-		"certid": certId,
+	deployed := 0
+	for _, d := range strings.Split(domain, ",") {
+		d = strings.TrimSpace(d)
+		if d == "" {
+			continue
+		}
+		path := fmt.Sprintf("domain/%v/sslize", d)
+		m := map[string]any{
+			"certid": certId,
+		}
+		var response commonResponse
+		if err = requestQiniu(cfg, path, m, "PUT", &response); err != nil {
+			return err
+		}
+		deployed++
 	}
-	var response commonResponse
-	err = requestQiniu(cfg, path, m, "PUT", &response)
-	return err
+	if deployed == 0 {
+		return fmt.Errorf("参数错误：domain")
+	}
+	return nil
 }
 
 func DeployQiniuOss(cfg map[string]any) error {
@@ -84,18 +98,31 @@ func DeployQiniuOss(cfg map[string]any) error {
 	if !ok {
 		return fmt.Errorf("参数错误：domain")
 	}
-	
+
 	certId, err := uploadQiniuCert(cfg)
 	if err != nil {
 		return err
 	}
-	m := map[string]any{
-		"certid": certId,
-		"domain": domain,
+	deployed := 0
+	for _, d := range strings.Split(domain, ",") {
+		d = strings.TrimSpace(d)
+		if d == "" {
+			continue
+		}
+		m := map[string]any{
+			"certid": certId,
+			"domain": d,
+		}
+		var response commonResponse
+		if err = requestQiniu(cfg, "cert/bind", m, "POST", &response); err != nil {
+			return err
+		}
+		deployed++
 	}
-	var response commonResponse
-	err = requestQiniu(cfg, "cert/bind", m, "POST", &response)
-	return err
+	if deployed == 0 {
+		return fmt.Errorf("参数错误：domain")
+	}
+	return nil
 }
 
 func uploadQiniuCert(cfg map[string]any) (string, error) {

--- a/plugins/alicloud/cdn/action.go
+++ b/plugins/alicloud/cdn/action.go
@@ -47,12 +47,25 @@ func Deploy(cfg map[string]any) error {
 	if err != nil {
 		return err
 	}
-	req := &aliyuncdn.SetCdnDomainSSLCertificateRequest{
-		DomainName:  tea.String(domain),
-		SSLProtocol: tea.String("on"),
-		SSLPub:      tea.String(strings.TrimSpace(certPEM)),
-		SSLPri:      tea.String(strings.TrimSpace(keyPEM)),
+	deployed := 0
+	for _, d := range strings.Split(domain, ",") {
+		d = strings.TrimSpace(d)
+		if d == "" {
+			continue
+		}
+		req := &aliyuncdn.SetCdnDomainSSLCertificateRequest{
+			DomainName:  tea.String(d),
+			SSLProtocol: tea.String("on"),
+			SSLPub:      tea.String(strings.TrimSpace(certPEM)),
+			SSLPri:      tea.String(strings.TrimSpace(keyPEM)),
+		}
+		if _, err = client.SetCdnDomainSSLCertificate(req); err != nil {
+			return err
+		}
+		deployed++
 	}
-	_, err = client.SetCdnDomainSSLCertificate(req)
-	return err
+	if deployed == 0 {
+		return fmt.Errorf("参数错误：domain")
+	}
+	return nil
 }

--- a/plugins/alicloud/dcdn/action.go
+++ b/plugins/alicloud/dcdn/action.go
@@ -2,6 +2,7 @@ package dcdn
 
 import (
 	"fmt"
+	"strings"
 
 	aliyunopenapi "github.com/alibabacloud-go/darabonba-openapi/v2/client"
 	dcdn "github.com/alibabacloud-go/dcdn-20180115/v3/client"
@@ -43,14 +44,27 @@ func Deploy(cfg map[string]any) error {
 	if err != nil {
 		return fmt.Errorf("创建 DCDN 客户端失败: %w", err)
 	}
-	req := &dcdn.SetDcdnDomainSSLCertificateRequest{
-		DomainName:  tea.String(domain),
-		SSLPri:      tea.String(keyPEM),
-		SSLPub:      tea.String(certPEM),
-		SSLProtocol: tea.String("on"),
-		CertType:    tea.String("upload"),
-	}
 	runtime := &util.RuntimeOptions{}
-	_, err = client.SetDcdnDomainSSLCertificateWithOptions(req, runtime)
-	return err
+	deployed := 0
+	for _, d := range strings.Split(domain, ",") {
+		d = strings.TrimSpace(d)
+		if d == "" {
+			continue
+		}
+		req := &dcdn.SetDcdnDomainSSLCertificateRequest{
+			DomainName:  tea.String(d),
+			SSLPri:      tea.String(keyPEM),
+			SSLPub:      tea.String(certPEM),
+			SSLProtocol: tea.String("on"),
+			CertType:    tea.String("upload"),
+		}
+		if _, err = client.SetDcdnDomainSSLCertificateWithOptions(req, runtime); err != nil {
+			return err
+		}
+		deployed++
+	}
+	if deployed == 0 {
+		return fmt.Errorf("参数错误：domain")
+	}
+	return nil
 }


### PR DESCRIPTION
【新增】阿里云CDN/DCDN和七牛云CDN/OSS支持多域名一次部署,在部署配置的域名配置处，支持添加多个通过逗号隔开的域名，一次将证书部署到多个域名加速，以简化多域名证书部署时的配置。