### PR TITLE
【调整】Webhook部署方式在推送回调数据时支持使用 __domain__  模板变量

### DIFF
--- a/backend/internal/cert/deploy/webhook/deploy.go
+++ b/backend/internal/cert/deploy/webhook/deploy.go
@@ -3,7 +3,9 @@ package webhook
 import (
 	"ALLinSSL/backend/internal/access"
 	"ALLinSSL/backend/public"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"strconv"
 )
@@ -69,8 +71,17 @@ func Deploy(cfg map[string]any) error {
 	if !ok || keyStr == "" {
 		return fmt.Errorf("key is required and must be a string")
 	}
+	domain, _ := cfg["domain"].(string)
+	if domain == "" {
+		block, _ := pem.Decode([]byte(certStr))
+		if block != nil && block.Type == "CERTIFICATE" {
+			if certObj, err := x509.ParseCertificate(block.Bytes); err == nil {
+				domain = certObj.Subject.CommonName
+			}
+		}
+	}
 
-	data, err := public.ReplaceJSONPlaceholders(providerConfig.Data, map[string]interface{}{"key": keyStr, "cert": certStr})
+	data, err := public.ReplaceJSONPlaceholders(providerConfig.Data, map[string]interface{}{"key": keyStr, "cert": certStr, "domain": domain})
 	if err != nil {
 		return fmt.Errorf("替换JSON占位符失败: %w", err)
 	}

--- a/frontend/apps/allin-ssl/src/views/authApiManage/useController.tsx
+++ b/frontend/apps/allin-ssl/src/views/authApiManage/useController.tsx
@@ -1321,6 +1321,12 @@ export const useApiFormController = (
                         </code>
                         <span class="text-color5">：私钥内容</span>
                       </div>
+                      <div>
+                        <code class="px-2 py-1 bg-[var(--form-log-code-bg)] rounded text-lg font-mono">
+                          __domain__
+                        </code>
+                        <span class="text-color5">：主域名（如 example.com）</span>
+                      </div>
                     </div>
                   </div>
                   <div>


### PR DESCRIPTION
关联： https://github.com/allinssl/allinssl/issues/530