### PR TITLE
docs: add Sealos deploy badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ We are actively improving the following features. Feel free to suggest via [GitH
 
 ## 🚀 Quick Start
 
+### Deploy on Sealos
+Launch AllinSSL on Sealos with one click:
+
+[![](https://raw.githubusercontent.com/labring-actions/templates/main/Deploy-on-Sealos.svg)](https://gzg.sealos.run/?openapp=system-template%3FtemplateName%3DAllinSSL&uid=W1Rq6kLI_b)
+
 ### System Requirements
 - Linux
 - macOS / Windows (script installation not yet supported; see manual steps below)


### PR DESCRIPTION
This PR adds a Deploy on Sealos badge to the English README quick start section for one-click deployment.