### PR TITLE
fix: tolerate mixed SafeLine WAF config values

### DIFF
--- a/backend/internal/cert/deploy/safelinewaf.go
+++ b/backend/internal/cert/deploy/safelinewaf.go
@@ -13,6 +13,59 @@ import (
 	"strconv"
 )
 
+type safeLineWafConfig struct {
+	URL       string
+	APIToken  string
+	IgnoreSSL bool
+}
+
+func parseSafeLineWafConfig(configJSON string) (safeLineWafConfig, error) {
+	var rawConfig struct {
+		URL       string          `json:"url"`
+		APIToken  string          `json:"api_token"`
+		IgnoreSSL json.RawMessage `json:"ignore_ssl"`
+	}
+	if err := json.Unmarshal([]byte(configJSON), &rawConfig); err != nil {
+		return safeLineWafConfig{}, err
+	}
+
+	config := safeLineWafConfig{
+		URL:      rawConfig.URL,
+		APIToken: rawConfig.APIToken,
+	}
+	value := bytes.TrimSpace(rawConfig.IgnoreSSL)
+	if len(value) == 0 || bytes.Equal(value, []byte("null")) {
+		return config, nil
+	}
+
+	if value[0] == '"' {
+		var stringValue string
+		if err := json.Unmarshal(value, &stringValue); err != nil {
+			return safeLineWafConfig{}, err
+		}
+		ignoreSSL, err := strconv.ParseBool(stringValue)
+		if err != nil {
+			return safeLineWafConfig{}, fmt.Errorf("invalid ignore_ssl value %q", stringValue)
+		}
+		config.IgnoreSSL = ignoreSSL
+		return config, nil
+	}
+
+	var boolValue bool
+	if err := json.Unmarshal(value, &boolValue); err == nil {
+		config.IgnoreSSL = boolValue
+		return config, nil
+	}
+
+	var numberValue float64
+	if err := json.Unmarshal(value, &numberValue); err == nil && (numberValue == 0 || numberValue == 1) {
+		config.IgnoreSSL = numberValue == 1
+		return config, nil
+	}
+
+	return safeLineWafConfig{}, fmt.Errorf("invalid ignore_ssl value %s", value)
+}
+
 func RequestSafeLineWaf(data *map[string]any, method, providerID, requestUrl string) (map[string]any, error) {
 	providerData, err := access.GetAccess(providerID)
 	if err != nil {
@@ -23,13 +76,12 @@ func RequestSafeLineWaf(data *map[string]any, method, providerID, requestUrl str
 		return nil, fmt.Errorf("api配置错误")
 	}
 	// 解析 JSON 配置
-	var providerConfig map[string]string
-	err = json.Unmarshal([]byte(providerConfigStr), &providerConfig)
+	providerConfig, err := parseSafeLineWafConfig(providerConfigStr)
 	if err != nil {
 		return nil, err
 	}
 
-	parsedURL, err := url.Parse(providerConfig["url"])
+	parsedURL, err := url.Parse(providerConfig.URL)
 	if err != nil {
 		return nil, err
 	}
@@ -41,16 +93,12 @@ func RequestSafeLineWaf(data *map[string]any, method, providerID, requestUrl str
 		return nil, err
 	}
 
-	req.Header.Set("X-SLCE-API-TOKEN", providerConfig["api_token"])
+	req.Header.Set("X-SLCE-API-TOKEN", providerConfig.APIToken)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("user-agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36")
 	// 自定义 Transport，跳过 SSL 证书验证
-	ignoreSsl := false
-	if providerConfig["ignore_ssl"] == "1" {
-		ignoreSsl = true
-	}
 	tr := &http.Transport{
-		TLSClientConfig:   &tls.Config{InsecureSkipVerify: ignoreSsl},
+		TLSClientConfig:   &tls.Config{InsecureSkipVerify: providerConfig.IgnoreSSL},
 		DisableKeepAlives: true,
 	}
 

--- a/backend/internal/cert/deploy/safelinewaf_config_test.go
+++ b/backend/internal/cert/deploy/safelinewaf_config_test.go
@@ -1,0 +1,54 @@
+package deploy
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func mustMarshalJSON(t *testing.T, value any) string {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	return string(data)
+}
+
+func TestParseSafeLineWafConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		ignoreSSL any
+		want      bool
+	}{
+		{name: "string one", ignoreSSL: "1", want: true},
+		{name: "number one", ignoreSSL: 1, want: true},
+		{name: "boolean true", ignoreSSL: true, want: true},
+		{name: "string zero", ignoreSSL: "0", want: false},
+		{name: "number zero", ignoreSSL: 0, want: false},
+		{name: "boolean false", ignoreSSL: false, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configJSON := fmt.Sprintf(
+				`{"url":"https://waf.local:9443/","api_token":"token","ignore_ssl":%s,"port":22}`,
+				mustMarshalJSON(t, tt.ignoreSSL),
+			)
+
+			config, err := parseSafeLineWafConfig(configJSON)
+			if err != nil {
+				t.Fatalf("parseSafeLineWafConfig() error = %v", err)
+			}
+			if config.URL != "https://waf.local:9443/" {
+				t.Errorf("URL = %q, want %q", config.URL, "https://waf.local:9443/")
+			}
+			if config.APIToken != "token" {
+				t.Errorf("APIToken = %q, want %q", config.APIToken, "token")
+			}
+			if config.IgnoreSSL != tt.want {
+				t.Errorf("IgnoreSSL = %v, want %v", config.IgnoreSSL, tt.want)
+			}
+		})
+	}
+}

--- a/frontend/apps/allin-ssl/src/views/authApiManage/useController.tsx
+++ b/frontend/apps/allin-ssl/src/views/authApiManage/useController.tsx
@@ -1670,6 +1670,13 @@ export const useApiFormController = (
             ignore_ssl: "0",
           };
           break;
+        case "safeline":
+          param.value.config = {
+            url: "",
+            api_token: "",
+            ignore_ssl: "0",
+          };
+          break;
         case "aliyun":
           param.value.config = {
             access_key_id: "",


### PR DESCRIPTION
## 修改内容

- 为雷池 WAF 配置增加专用解析逻辑，只读取 `url`、`api_token` 和 `ignore_ssl`，忽略 `port` 等无关字段
- 兼容 `ignore_ssl` 的 string、number 和 boolean 表示
- 在授权类型切换到雷池时重置为雷池专属字段，避免 SSH 配置残留
- 添加包含额外 numeric `port` 字段的回归测试

## 根因

授权表单缺少 `safeline` 类型的配置重置分支，从 SSH 切换后会把 `port: 22` 等字段一并保存。后端使用 `map[string]string` 反序列化整段 JSON，因此遇到数值或布尔字段时会在读取雷池配置前失败。

Fixes #543

## 验证

- `go test -vet=off ./backend/internal/cert/deploy -run TestParseSafeLineWafConfig -count=1` ✅
- `go test -vet=off ./backend/internal/cert/deploy -run '^$' -count=1` ✅（包编译）
- `git diff --check` ✅

## 已知基线限制

- 默认 Go 测试会被现有 `safelinewaf_test.go:52` 的 Go 1.26 vet 规则拦截（动态 format string）。
- deploy 包全量测试依赖本地数据库和硬编码 `D:/code/ALLinSSL` 路径，在当前环境中已有多项失败。
- 前端全量 `vue-tsc` 可运行，但仓库当前存在大量既有的路径大小写、缺失 workspace 构建产物和类型错误；本次修改行没有新增诊断。
