### PR TITLE
证书吊销和批量删除

### DIFF
--- a/backend/app/api/cert.go
+++ b/backend/app/api/cert.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"ALLinSSL/backend/internal/cert"
+	"ALLinSSL/backend/internal/cert/apply"
 	"ALLinSSL/backend/public"
 	"archive/zip"
 	"bytes"
@@ -80,6 +81,40 @@ func DelCert(c *gin.Context) {
 	}
 	public.SuccessMsg(c, "删除成功")
 	return
+}
+
+func RevokeCert(c *gin.Context) {
+	var form struct {
+		ID         string `form:"id"`
+		Reason     int    `form:"reason"`
+		ReasonNote string `form:"reason_note"`
+	}
+	err := c.Bind(&form)
+	if err != nil {
+		public.FailMsg(c, err.Error())
+		return
+	}
+	if form.ID == "" {
+		public.FailMsg(c, "ID不能为空")
+		return
+	}
+	err = apply.RevokeCert(form.ID, form.Reason, strings.TrimSpace(form.ReasonNote))
+	if err != nil {
+		public.FailMsg(c, err.Error())
+		return
+	}
+	public.SuccessMsg(c, "吊销成功")
+	return
+}
+
+// BackfillACME 从工作流配置回填历史证书的 ACME 账户元数据。
+func BackfillACME(c *gin.Context) {
+	n, err := cert.BackfillACMEMetadata()
+	if err != nil {
+		public.FailMsg(c, err.Error())
+		return
+	}
+	public.SuccessData(c, map[string]any{"updated": n}, n)
 }
 
 func DownloadCert(c *gin.Context) {

--- a/backend/app/api/private_ca/private_ca.go
+++ b/backend/app/api/private_ca/private_ca.go
@@ -123,6 +123,52 @@ func GetLeafCertList(c *gin.Context) {
 
 func DeleteLeafCert(c *gin.Context) {
 	var form struct {
+		Id string `form:"id"`
+	}
+	err := c.Bind(&form)
+	if err != nil {
+		public.FailMsg(c, err.Error())
+		return
+	}
+	if strings.TrimSpace(form.Id) == "" {
+		public.FailMsg(c, "ID不能为空")
+		return
+	}
+	err = private_ca.DeleteLeafCerts(form.Id)
+	if err != nil {
+		public.FailMsg(c, err.Error())
+		return
+	}
+	public.SuccessMsg(c, "删除成功")
+	return
+}
+
+func RevokeLeafCert(c *gin.Context) {
+	var form struct {
+		Id         string `form:"id"`
+		Reason     int    `form:"reason"`
+		ReasonNote string `form:"reason_note"`
+	}
+	err := c.Bind(&form)
+	if err != nil {
+		public.FailMsg(c, err.Error())
+		return
+	}
+	if strings.TrimSpace(form.Id) == "" {
+		public.FailMsg(c, "ID不能为空")
+		return
+	}
+	err = private_ca.RevokeLeafCerts(form.Id, form.Reason, strings.TrimSpace(form.ReasonNote))
+	if err != nil {
+		public.FailMsg(c, err.Error())
+		return
+	}
+	public.SuccessMsg(c, "吊销成功")
+	return
+}
+
+func DownloadCRL(c *gin.Context) {
+	var form struct {
 		Id int64 `form:"id"`
 	}
 	err := c.Bind(&form)
@@ -131,16 +177,53 @@ func DeleteLeafCert(c *gin.Context) {
 		return
 	}
 	if form.Id <= 0 {
-		public.FailMsg(c, "ID不能为空")
+		public.FailMsg(c, "CA ID不能为空")
 		return
 	}
-	err = private_ca.DeleteLeafCert(form.Id)
+	crlPEM, filename, err := private_ca.GenerateCRL(form.Id)
 	if err != nil {
 		public.FailMsg(c, err.Error())
 		return
 	}
-	public.SuccessMsg(c, "删除成功")
+	c.Header("Content-Type", "application/pkix-crl")
+	c.Header("Content-Disposition", "attachment; filename="+filename)
+	c.Data(200, "application/pkix-crl", crlPEM)
 	return
+}
+
+// DownloadCRLPublic 公开 CRL 下载，供证书 CDP 扩展引用（无需登录）。
+// 参数：ca_id
+func DownloadCRLPublic(c *gin.Context) {
+	var form struct {
+		CaId int64 `form:"ca_id"`
+	}
+	_ = c.Bind(&form)
+	if form.CaId <= 0 {
+		// 兼容 id
+		var alt struct {
+			Id int64 `form:"id"`
+		}
+		_ = c.Bind(&alt)
+		form.CaId = alt.Id
+	}
+	if form.CaId <= 0 {
+		public.FailMsg(c, "ca_id不能为空")
+		return
+	}
+	crlPEM, filename, err := private_ca.GenerateCRL(form.CaId)
+	if err != nil {
+		public.FailMsg(c, err.Error())
+		return
+	}
+	c.Header("Content-Type", "application/pkix-crl")
+	c.Header("Content-Disposition", "attachment; filename="+filename)
+	c.Header("Cache-Control", "public, max-age=3600")
+	c.Data(200, "application/pkix-crl", crlPEM)
+}
+
+// HandleOCSP 公开 OCSP 应答（无需登录）
+func HandleOCSP(c *gin.Context) {
+	private_ca.HandleOCSP(c)
 }
 
 func DownloadCert(c *gin.Context) {

--- a/backend/internal/cert/apply/apply.go
+++ b/backend/internal/cert/apply/apply.go
@@ -571,6 +571,10 @@ func FindMatchedCert(runId string, domainArr []string) (*MatchedCert, error) {
 		now       = time.Now()
 	)
 	for i := range certs {
+		// 已吊销证书不可复用
+		if status, _ := certs[i]["status"].(string); status == cert.CertStatusRevoked {
+			continue
+		}
 		if !public.ContainsAllIgnoreBRepeats(strings.Split(certs[i]["domains"].(string), ","), domainArr) {
 			continue
 		}
@@ -1029,7 +1033,12 @@ func Apply(cfg map[string]any, logger *public.Logger) (map[string]any, error) {
 		"issuerCert": issuerCertStr,
 	}
 
-	_, err = cert.SaveCert("workflow", keyStr, certStr, issuerCertStr, runId)
+	// 规范化 CA 标识，便于吊销时找回账户
+	acmeCA := ca
+	if acmeCA == "" || acmeCA == "letsencrypt" {
+		acmeCA = "Let's Encrypt"
+	}
+	_, err = cert.SaveCert("workflow", keyStr, certStr, issuerCertStr, runId, email, acmeCA)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/cert/apply/revoke.go
+++ b/backend/internal/cert/apply/revoke.go
@@ -1,0 +1,169 @@
+package apply
+
+import (
+	"ALLinSSL/backend/internal/cert"
+	"ALLinSSL/backend/public"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/go-acme/lego/v4/certcrypto"
+	"github.com/go-acme/lego/v4/lego"
+	"github.com/go-acme/lego/v4/log"
+)
+
+// GetRegisteredAcmeClient 加载已注册的 ACME 账户客户端；不存在或未注册则返回错误（不会自动注册新账户）。
+func GetRegisteredAcmeClient(email, ca string, logger *public.Logger) (*lego.Client, error) {
+	if email == "" {
+		return nil, fmt.Errorf("ACME 账户邮箱不能为空")
+	}
+	if ca == "" || ca == "letsencrypt" {
+		ca = "Let's Encrypt"
+	}
+
+	db, err := GetSqlite()
+	if err != nil {
+		return nil, fmt.Errorf("连接账户数据库失败: %w", err)
+	}
+	defer db.Close()
+
+	accData, err := GetAccount(db, email, ca)
+	if err != nil || accData == nil {
+		return nil, fmt.Errorf("未找到 CA【%s】下邮箱为 %s 的 ACME 账户，请先在账号管理中确认", ca, email)
+	}
+
+	user := GetAcmeUser(email, logger, accData)
+	if user == nil || user.Registration == nil {
+		return nil, fmt.Errorf("ACME 账户 %s 尚未完成注册，无法吊销。请先用该账户成功申请过一次证书", email)
+	}
+	if user.GetPrivateKey() == nil {
+		return nil, fmt.Errorf("ACME 账户 %s 私钥不可用", email)
+	}
+
+	CADirURL := CADirURLMap[ca]
+	if CADirURL == "" {
+		if v, ok := accData["CADirURL"].(string); ok && v != "" {
+			CADirURL = v
+		}
+	}
+	if CADirURL == "" {
+		return nil, fmt.Errorf("未找到 CA【%s】的目录地址", ca)
+	}
+
+	config := lego.NewConfig(user)
+	config.Certificate.KeyType = certcrypto.RSA2048
+	config.CADirURL = CADirURL
+	config.Certificate.Timeout = 60 * time.Second
+
+	client, err := lego.NewClient(config)
+	if err != nil {
+		return nil, fmt.Errorf("创建 ACME 客户端失败: %w", err)
+	}
+	return client, nil
+}
+
+// RevokeCert 向公网 CA 发起 ACME 吊销，并更新本地证书状态。
+// id 支持逗号分隔批量吊销；reason 使用 RFC 5280 §5.3.1 原因码。
+func RevokeCert(id string, reason int, reasonNote string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return fmt.Errorf("ID不能为空")
+	}
+	reasonStr, err := cert.FormatRevokeReason(reason, reasonNote)
+	if err != nil {
+		return err
+	}
+
+	ids := strings.Split(id, ",")
+	var (
+		okCount   int
+		lastError error
+		messages  []string
+	)
+	for _, rawID := range ids {
+		rawID = strings.TrimSpace(rawID)
+		if rawID == "" {
+			continue
+		}
+		if err := revokeOneCert(rawID, reason, reasonStr); err != nil {
+			lastError = err
+			messages = append(messages, fmt.Sprintf("#%s: %v", rawID, err))
+			continue
+		}
+		okCount++
+	}
+	if okCount == 0 {
+		if lastError != nil {
+			if len(messages) == 1 {
+				return lastError
+			}
+			return fmt.Errorf("全部吊销失败: %s", strings.Join(messages, "; "))
+		}
+		return fmt.Errorf("ID不能为空")
+	}
+	if len(messages) > 0 {
+		return fmt.Errorf("成功 %d 个，失败 %d 个: %s", okCount, len(messages), strings.Join(messages, "; "))
+	}
+	return nil
+}
+
+func revokeOneCert(id string, reason int, reasonStr string) error {
+	row, err := cert.GetCertRow(id)
+	if err != nil {
+		return err
+	}
+	if status, _ := row["status"].(string); status == cert.CertStatusRevoked {
+		return fmt.Errorf("证书已吊销，无需重复操作")
+	}
+	source, _ := row["source"].(string)
+	if source == "upload" {
+		return fmt.Errorf("上传证书无法通过 ACME 吊销，请直接删除本地记录")
+	}
+
+	certPEM, _ := row["cert"].(string)
+	if certPEM == "" {
+		return fmt.Errorf("证书内容为空")
+	}
+
+	email, _ := row["acme_email"].(string)
+	ca, _ := row["acme_ca"].(string)
+	if email == "" {
+		return fmt.Errorf("该证书未记录 ACME 账户邮箱，无法自动吊销")
+	}
+	if ca == "" {
+		ca = "Let's Encrypt"
+	}
+
+	logPath := filepath.Join("logs", "acme_revoke.log")
+	_ = os.MkdirAll(filepath.Dir(logPath), 0o755)
+	logger, err := public.NewLogger(logPath)
+	if err != nil {
+		logger, err = public.NewLogger(filepath.Join("logs", "workflows", "acme_revoke.log"))
+		if err != nil {
+			return fmt.Errorf("初始化吊销日志失败: %v", err)
+		}
+	}
+	defer logger.Close()
+	log.Logger = logger.GetLogger()
+
+	client, err := GetRegisteredAcmeClient(email, ca, logger)
+	if err != nil {
+		return err
+	}
+
+	reasonUint := uint(reason)
+	if err := client.Certificate.RevokeWithReason([]byte(certPEM), &reasonUint); err != nil {
+		errMsg := strings.ToLower(err.Error())
+		if !strings.Contains(errMsg, "alreadyrevoked") && !strings.Contains(errMsg, "already revoked") {
+			return fmt.Errorf("向 CA 吊销失败: %v", err)
+		}
+		logger.Debug("CA 返回证书已吊销，同步本地状态")
+	}
+
+	if err := cert.MarkCertRevoked(row["id"], reasonStr); err != nil {
+		return fmt.Errorf("CA 侧已处理，但更新本地状态失败: %v", err)
+	}
+	return nil
+}

--- a/backend/internal/cert/backfill.go
+++ b/backend/internal/cert/backfill.go
@@ -1,0 +1,134 @@
+package cert
+
+import (
+	"ALLinSSL/backend/public"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// workflowNode 仅用于回填时解析工作流 JSON，字段与 workflow.WorkflowNode 对齐。
+type workflowNode struct {
+	Type           string          `json:"type"`
+	Config         map[string]any  `json:"config"`
+	ChildNode      *workflowNode   `json:"childNode"`
+	ConditionNodes []*workflowNode `json:"conditionNodes"`
+}
+
+// BackfillACMEMetadata 为历史证书补全 acme_email / acme_ca。
+// 从关联工作流 content 中查找 apply 节点的 email、ca 配置。
+// 返回成功回填的条数。
+func BackfillACMEMetadata() (int, error) {
+	s, err := GetSqlite()
+	if err != nil {
+		return 0, err
+	}
+	defer s.Close()
+
+	rows, err := s.Where("source=? and (acme_email is null or acme_email='') and workflow_id is not null and workflow_id!=''", []interface{}{"workflow"}).Select()
+	if err != nil {
+		return 0, err
+	}
+	if len(rows) == 0 {
+		return 0, nil
+	}
+
+	type meta struct {
+		email string
+		ca    string
+	}
+	cache := map[string]meta{}
+	updated := 0
+
+	for _, row := range rows {
+		wfID, _ := row["workflow_id"].(string)
+		if wfID == "" {
+			continue
+		}
+		m, ok := cache[wfID]
+		if !ok {
+			email, ca, err := extractACMEFromWorkflow(wfID)
+			if err != nil || email == "" {
+				cache[wfID] = meta{}
+				continue
+			}
+			if ca == "" || ca == "letsencrypt" {
+				ca = "Let's Encrypt"
+			}
+			m = meta{email: email, ca: ca}
+			cache[wfID] = m
+		}
+		if m.email == "" {
+			continue
+		}
+		_, err = s.Where("id=?", []interface{}{row["id"]}).Update(map[string]interface{}{
+			"acme_email": m.email,
+			"acme_ca":    m.ca,
+		})
+		if err != nil {
+			return updated, fmt.Errorf("更新证书 %v 失败: %w", row["id"], err)
+		}
+		updated++
+	}
+	return updated, nil
+}
+
+func extractACMEFromWorkflow(workflowID string) (email, ca string, err error) {
+	s, err := public.NewSqlite("data/data.db", "")
+	if err != nil {
+		return "", "", err
+	}
+	defer s.Close()
+	s.TableName = "workflow"
+	rows, err := s.Where("id=?", []interface{}{workflowID}).Select()
+	if err != nil {
+		return "", "", err
+	}
+	if len(rows) == 0 {
+		return "", "", fmt.Errorf("workflow %s not found", workflowID)
+	}
+	content, _ := rows[0]["content"].(string)
+	if content == "" {
+		return "", "", fmt.Errorf("empty content")
+	}
+	var root workflowNode
+	if err := json.Unmarshal([]byte(content), &root); err != nil {
+		return "", "", err
+	}
+	email, ca = findApplyACME(&root)
+	return email, ca, nil
+}
+
+func findApplyACME(node *workflowNode) (email, ca string) {
+	if node == nil {
+		return "", ""
+	}
+	if node.Type == "apply" && node.Config != nil {
+		if e, ok := node.Config["email"].(string); ok && strings.TrimSpace(e) != "" {
+			email = strings.TrimSpace(e)
+			if c, ok := node.Config["ca"].(string); ok {
+				ca = strings.TrimSpace(c)
+			}
+			if ca == "" {
+				if eab, ok := node.Config["eabId"].(string); ok {
+					switch eab {
+					case "", "let":
+						ca = "Let's Encrypt"
+					case "buy", "buypass":
+						ca = "buypass"
+					}
+				}
+			}
+			return email, ca
+		}
+	}
+	if e, c := findApplyACME(node.ChildNode); e != "" {
+		return e, c
+	}
+	for _, child := range node.ConditionNodes {
+		if e, c := findApplyACME(child); e != "" {
+			return e, c
+		}
+	}
+	return "", ""
+}

--- a/backend/internal/cert/cert.go
+++ b/backend/internal/cert/cert.go
@@ -8,6 +8,25 @@ import (
 	"time"
 )
 
+const (
+	CertStatusNormal  = "normal"
+	CertStatusRevoked = "revoked"
+)
+
+// validACMERevokeReasons RFC 5280 §5.3.1 原因码
+var validACMERevokeReasons = map[int]string{
+	0:  "unspecified",
+	1:  "keyCompromise",
+	2:  "cACompromise",
+	3:  "affiliationChanged",
+	4:  "superseded",
+	5:  "cessationOfOperation",
+	6:  "certificateHold",
+	8:  "removeFromCRL",
+	9:  "privilegeWithdrawn",
+	10: "aACompromise",
+}
+
 func GetSqlite() (*public.Sqlite, error) {
 	s, err := public.NewSqlite("data/data.db", "")
 	if err != nil {
@@ -35,22 +54,21 @@ func GetList(search string, p, limit, status int64) ([]map[string]any, int, erro
 		}
 	}
 
-	// 获取当前时间
 	now := time.Now()
-	// 转换为字符串格式
 	nowStr := now.Format("2006-01-02 15:04:05")
-	// 30 天后的时间
 	nowPlus30Days := now.AddDate(0, 0, 30)
 	nowPlus30DaysStr := nowPlus30Days.Format("2006-01-02 15:04:05")
 
 	filterSql := "1=1 "
-	// status: -1 已过期 0/其它 全部 1 即将过期 2 正常
-	if status == -1 {
-		filterSql += "and end_time <= '" + nowStr + "'"
+	// status: -2 已吊销 -1 已过期 0/其它 全部 1 即将过期 2 正常
+	if status == -2 {
+		filterSql += "and status = 'revoked' "
+	} else if status == -1 {
+		filterSql += "and (status is null or status = '' or status = 'normal') and end_time <= '" + nowStr + "' "
 	} else if status == 1 {
-		filterSql += "and end_time > '" + nowStr + "' AND end_time <= '" + nowPlus30DaysStr + "'"
+		filterSql += "and (status is null or status = '' or status = 'normal') and end_time > '" + nowStr + "' AND end_time <= '" + nowPlus30DaysStr + "' "
 	} else if status == 2 {
-		filterSql += "and end_time > '" + nowPlus30DaysStr + "'"
+		filterSql += "and (status is null or status = '' or status = 'normal') and end_time > '" + nowPlus30DaysStr + "' "
 	}
 
 	if search != "" {
@@ -68,11 +86,14 @@ func GetList(search string, p, limit, status int64) ([]map[string]any, int, erro
 			continue
 		}
 		v["end_day"] = strconv.FormatInt(int64(endtime.Sub(time.Now())/(24*time.Hour)), 10)
+		if st, _ := v["status"].(string); st == "" {
+			v["status"] = CertStatusNormal
+		}
 	}
 	return data, int(count), nil
 }
 
-func AddCert(source, key, cert, issuer, issuerCert, domains, sha256, historyId, startTime, endTime, endDay string) error {
+func AddCert(source, key, cert, issuer, issuerCert, domains, sha256, historyId, startTime, endTime, endDay, acmeEmail, acmeCA string) error {
 	s, err := GetSqlite()
 	if err != nil {
 		return err
@@ -86,7 +107,6 @@ func AddCert(source, key, cert, issuer, issuerCert, domains, sha256, historyId, 
 		}
 		s.TableName = "workflow_history"
 		defer s.Close()
-		// 查询 workflowId
 		wh, err := s.Where("id=?", []interface{}{historyId}).Select()
 		if err != nil {
 			return err
@@ -98,20 +118,24 @@ func AddCert(source, key, cert, issuer, issuerCert, domains, sha256, historyId, 
 
 	now := time.Now().Format("2006-01-02 15:04:05")
 	_, err = s.Insert(map[string]any{
-		"source":      source,
-		"key":         key,
-		"cert":        cert,
-		"issuer":      issuer,
-		"issuer_cert": issuerCert,
-		"domains":     domains,
-		"sha256":      sha256,
-		"history_id":  historyId,
-		"workflow_id": workflowId,
-		"create_time": now,
-		"update_time": now,
-		"start_time":  startTime,
-		"end_time":    endTime,
-		"end_day":     endDay,
+		"source":        source,
+		"key":           key,
+		"cert":          cert,
+		"issuer":        issuer,
+		"issuer_cert":   issuerCert,
+		"domains":       domains,
+		"sha256":        sha256,
+		"history_id":    historyId,
+		"workflow_id":   workflowId,
+		"create_time":   now,
+		"update_time":   now,
+		"start_time":    startTime,
+		"end_time":      endTime,
+		"end_day":       endDay,
+		"status":        CertStatusNormal,
+		"revoke_reason": "",
+		"acme_email":    acmeEmail,
+		"acme_ca":       acmeCA,
 	})
 	if err != nil {
 		return err
@@ -119,7 +143,8 @@ func AddCert(source, key, cert, issuer, issuerCert, domains, sha256, historyId, 
 	return nil
 }
 
-func SaveCert(source, key, cert, issuerCert, historyId string) (string, error) {
+// SaveCert 保存证书。acmeEmail/acmeCA 用于后续 ACME 吊销时定位账户；上传证书可传空。
+func SaveCert(source, key, cert, issuerCert, historyId, acmeEmail, acmeCA string) (string, error) {
 	if err := public.ValidateSSLCertificate(cert, key); err != nil {
 		return "", err
 	}
@@ -128,7 +153,6 @@ func SaveCert(source, key, cert, issuerCert, historyId string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("解析证书失败: %v", err)
 	}
-	// SHA256
 	sha256, err := public.GetSHA256(cert)
 	if err != nil {
 		return "", fmt.Errorf("获取 SHA256 失败: %v", err)
@@ -138,38 +162,33 @@ func SaveCert(source, key, cert, issuerCert, historyId string) (string, error) {
 	}
 
 	domainSet := make(map[string]bool)
-
 	if certObj.Subject.CommonName != "" {
 		domainSet[certObj.Subject.CommonName] = true
 	}
 	for _, dns := range certObj.DNSNames {
 		domainSet[dns] = true
 	}
-	// 处理 IP 地址
 	for _, ip := range certObj.IPAddresses {
 		domainSet[ip.String()] = true
 	}
 
-	// 转成切片并拼接成逗号分隔的字符串
 	var domains []string
 	for domain := range domainSet {
 		domains = append(domains, domain)
 	}
 	domainList := strings.Join(domains, ",")
 
-	// 提取 CA 名称（Issuer 的组织名）
 	caName := "UNKNOWN"
 	if len(certObj.Issuer.Organization) > 0 {
 		caName = certObj.Issuer.Organization[0]
 	} else if certObj.Issuer.CommonName != "" {
 		caName = certObj.Issuer.CommonName
 	}
-	// 证书有效期
 	startTime := certObj.NotBefore.Format("2006-01-02 15:04:05")
 	endTime := certObj.NotAfter.Format("2006-01-02 15:04:05")
 	endDay := fmt.Sprintf("%d", int(certObj.NotAfter.Sub(time.Now()).Hours()/24))
 
-	err = AddCert(source, key, cert, caName, issuerCert, domainList, sha256, historyId, startTime, endTime, endDay)
+	err = AddCert(source, key, cert, caName, issuerCert, domainList, sha256, historyId, startTime, endTime, endDay, acmeEmail, acmeCA)
 	if err != nil {
 		return "", fmt.Errorf("保存证书失败: %v", err)
 	}
@@ -177,7 +196,7 @@ func SaveCert(source, key, cert, issuerCert, historyId string) (string, error) {
 }
 
 func UploadCert(key, cert string) (string, error) {
-	sha256, err := SaveCert("upload", key, cert, "", "")
+	sha256, err := SaveCert("upload", key, cert, "", "", "", "")
 	if err != nil {
 		return sha256, fmt.Errorf("保存证书失败: %v", err)
 	}
@@ -220,6 +239,52 @@ func GetCert(id string) (map[string]string, error) {
 	}
 
 	return data, nil
+}
+
+// GetCertRow 返回完整证书行（含 ACME 元数据），供吊销流程使用。
+func GetCertRow(id string) (map[string]any, error) {
+	s, err := GetSqlite()
+	if err != nil {
+		return nil, err
+	}
+	defer s.Close()
+	res, err := s.Where("id=? or sha256=?", []interface{}{id, id}).Select()
+	if err != nil {
+		return nil, err
+	}
+	if len(res) == 0 {
+		return nil, fmt.Errorf("证书不存在")
+	}
+	return res[0], nil
+}
+
+// MarkCertRevoked 将证书标记为已吊销（本地状态）。
+func MarkCertRevoked(id any, reason string) error {
+	s, err := GetSqlite()
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+	now := time.Now().Format("2006-01-02 15:04:05")
+	_, err = s.Where("id=?", []interface{}{id}).Update(map[string]interface{}{
+		"status":        CertStatusRevoked,
+		"revoke_reason": reason,
+		"revoked_at":    now,
+		"update_time":   now,
+	})
+	return err
+}
+
+// FormatRevokeReason 将原因码与备注格式化为存储字符串。
+func FormatRevokeReason(reason int, reasonNote string) (string, error) {
+	label, ok := validACMERevokeReasons[reason]
+	if !ok {
+		return "", fmt.Errorf("不支持的吊销原因码: %d", reason)
+	}
+	if reasonNote != "" {
+		return label + ": " + reasonNote, nil
+	}
+	return label, nil
 }
 
 // ========================================================

--- a/backend/internal/private_ca/crl.go
+++ b/backend/internal/private_ca/crl.go
@@ -1,0 +1,169 @@
+package private_ca
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+)
+
+// GenerateCRL 为指定 CA（中间 CA 或根 CA）生成 PEM 编码的 CRL。
+// 包含该 CA 直接签发的、状态为 revoked 的叶子证书。
+// SM2 国密暂不支持 CRL 导出。
+func GenerateCRL(caId int64) ([]byte, string, error) {
+	if caId <= 0 {
+		return nil, "", fmt.Errorf("CA ID 无效")
+	}
+	s, err := GetSqlite()
+	if err != nil {
+		return nil, "", err
+	}
+	defer s.Close()
+
+	cas, err := s.Where("id=?", []interface{}{caId}).Select()
+	if err != nil {
+		return nil, "", err
+	}
+	if len(cas) == 0 {
+		return nil, "", fmt.Errorf("CA 不存在")
+	}
+	caRow := cas[0]
+	algorithm, _ := caRow["algorithm"].(string)
+	if algorithm == "sm2" {
+		return nil, "", fmt.Errorf("国密 SM2 证书暂不支持导出 CRL")
+	}
+
+	certPEM, _ := caRow["cert"].(string)
+	keyPEM, _ := caRow["key"].(string)
+	if certPEM == "" || keyPEM == "" {
+		return nil, "", fmt.Errorf("CA 证书或私钥为空")
+	}
+
+	issuerObj, err := NewCertificateFromPEMStandard([]byte(certPEM), []byte(keyPEM), KeyType(algorithm))
+	if err != nil {
+		return nil, "", fmt.Errorf("解析 CA 密钥失败: %v", err)
+	}
+	if issuerObj.Cert == nil {
+		return nil, "", fmt.Errorf("CA 证书解析失败")
+	}
+	signer, ok := issuerObj.Key.(crypto.Signer)
+	if !ok {
+		return nil, "", fmt.Errorf("CA 私钥不支持签名")
+	}
+
+	// 收集该 CA 下已吊销的叶子证书
+	s.TableName = "leaf"
+	leafs, err := s.Where("ca_id=? and status=?", []interface{}{caId, LeafStatusRevoked}).Select()
+	if err != nil {
+		return nil, "", err
+	}
+
+	var entries []x509.RevocationListEntry
+	for _, leaf := range leafs {
+		serial, err := resolveLeafSerial(leaf)
+		if err != nil || serial == nil {
+			continue
+		}
+		revokedAt := time.Now()
+		if v, ok := leaf["revoked_at"].(string); ok && v != "" {
+			if t, err := time.Parse("2006-01-02 15:04:05", v); err == nil {
+				revokedAt = t
+			}
+		}
+		reasonCode := parseRevokeReasonCode(leaf["revoke_reason"])
+		entry := x509.RevocationListEntry{
+			SerialNumber:   serial,
+			RevocationTime: revokedAt,
+		}
+		if reasonCode >= 0 {
+			entry.ReasonCode = reasonCode
+		}
+		entries = append(entries, entry)
+	}
+
+	now := time.Now()
+	template := &x509.RevocationList{
+		Number:                    big.NewInt(now.UnixNano()),
+		ThisUpdate:                now,
+		NextUpdate:                now.Add(7 * 24 * time.Hour),
+		RevokedCertificateEntries: entries,
+	}
+
+	crlDER, err := x509.CreateRevocationList(rand.Reader, template, issuerObj.Cert, signer)
+	if err != nil {
+		return nil, "", fmt.Errorf("生成 CRL 失败: %v", err)
+	}
+	crlPEM := pem.EncodeToMemory(&pem.Block{Type: "X509 CRL", Bytes: crlDER})
+
+	name, _ := caRow["name"].(string)
+	if name == "" {
+		name, _ = caRow["cn"].(string)
+	}
+	filename := sanitizeFilename(name) + ".crl"
+	return crlPEM, filename, nil
+}
+
+func resolveLeafSerial(leaf map[string]any) (*big.Int, error) {
+	if sn, ok := leaf["serial_number"].(string); ok && sn != "" {
+		serial := new(big.Int)
+		// 优先十六进制
+		if _, ok := serial.SetString(sn, 16); ok {
+			return serial, nil
+		}
+		if _, ok := serial.SetString(sn, 10); ok {
+			return serial, nil
+		}
+	}
+	certPEM, _ := leaf["cert"].(string)
+	if certPEM == "" {
+		return nil, fmt.Errorf("empty cert")
+	}
+	certObj, err := publicParseLeafCert(certPEM)
+	if err != nil {
+		return nil, err
+	}
+	return certObj.SerialNumber, nil
+}
+
+func publicParseLeafCert(certPEM string) (*x509.Certificate, error) {
+	block, _ := pem.Decode([]byte(certPEM))
+	if block == nil {
+		return nil, fmt.Errorf("无法解析证书 PEM")
+	}
+	return x509.ParseCertificate(block.Bytes)
+}
+
+// parseRevokeReasonCode 从存储的原因字符串提取 RFC 原因码；无法识别时返回 -1（不写入 ReasonCode）
+func parseRevokeReasonCode(v any) int {
+	s, _ := v.(string)
+	if s == "" {
+		return 0
+	}
+	// 格式: "keyCompromise" 或 "keyCompromise: note"
+	label := s
+	if i := strings.Index(s, ":"); i >= 0 {
+		label = strings.TrimSpace(s[:i])
+	}
+	for code, name := range validRevokeReasons {
+		if name == label {
+			return code
+		}
+	}
+	return 0
+}
+
+func sanitizeFilename(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "ca"
+	}
+	replacer := strings.NewReplacer(
+		"/", "_", "\\", "_", ":", "_", "*", "_",
+		"?", "_", "\"", "_", "<", "_", ">", "_", "|", "_", " ", "_",
+	)
+	return replacer.Replace(name)
+}

--- a/backend/internal/private_ca/leaf.go
+++ b/backend/internal/private_ca/leaf.go
@@ -11,8 +11,9 @@ import (
 	"time"
 )
 
-// GenerateLeafCertificate 生成叶子证书（服务器/客户端证书/邮件证书）
-func GenerateLeafCertificate(commonName string, san SAN, issuer *Certificate, keyType KeyType, usage int, keyBits int, validDays int) (*LeafCertConfig, error) {
+// GenerateLeafCertificate 生成叶子证书（服务器/客户端证书/邮件证书）。
+// caId 用于写入 CRL Distribution Point / OCSP 扩展；<=0 时跳过扩展。
+func GenerateLeafCertificate(commonName string, san SAN, issuer *Certificate, keyType KeyType, usage int, keyBits int, validDays int, caId int64) (*LeafCertConfig, error) {
 	if issuer == nil {
 		return nil, errors.New("issuer is nil")
 	}
@@ -84,17 +85,18 @@ func GenerateLeafCertificate(commonName string, san SAN, issuer *Certificate, ke
 
 		// 6. 组装返回结果
 		return &LeafCertConfig{
-			CN:         commonName,
-			Usage:      int64(usage),
-			Cert:       string(signCert.CertPEM),
-			Key:        string(signCert.KeyPEM),
-			EnCert:     string(encryptCert.CertPEM),
-			EnKey:      string(encryptCert.KeyPEM),
-			Algorithm:  "sm2",
-			KeyLength:  256,
-			NotAfter:   expire.Format("2006-01-02 15:04:05"),
-			NotBefore:  now.Format("2006-01-02 15:04:05"),
-			CreateTime: now.Format("2006-01-02 15:04:05"),
+			CN:           commonName,
+			Usage:        int64(usage),
+			Cert:         string(signCert.CertPEM),
+			Key:          string(signCert.KeyPEM),
+			EnCert:       string(encryptCert.CertPEM),
+			EnKey:        string(encryptCert.KeyPEM),
+			Algorithm:    "sm2",
+			KeyLength:    256,
+			NotAfter:     expire.Format("2006-01-02 15:04:05"),
+			NotBefore:    now.Format("2006-01-02 15:04:05"),
+			CreateTime:   now.Format("2006-01-02 15:04:05"),
+			SerialNumber: fmt.Sprintf("%x", signTmpl.SerialNumber),
 		}, nil
 	}
 
@@ -122,20 +124,26 @@ func GenerateLeafCertificate(commonName string, san SAN, issuer *Certificate, ke
 
 	tmpl.DNSNames = san.DNSNames
 	tmpl.IPAddresses = san.IPAddresses
+	// 写入 CDP / OCSP 扩展，便于客户端拉取吊销状态
+	if caId > 0 {
+		tmpl.CRLDistributionPoints = []string{CRLDistributionURL(caId)}
+		tmpl.OCSPServer = []string{OCSPServerURL()}
+	}
 	cert, err := signCert(tmpl, issuer.Cert, priv, issuer.Key, keyType)
 	if err != nil {
 		return nil, err
 	}
 	cert.KeyType = keyType
 	return &LeafCertConfig{
-		CN:         commonName,
-		Usage:      int64(usage),
-		Cert:       string(cert.CertPEM),
-		Key:        string(cert.KeyPEM),
-		Algorithm:  string(keyType),
-		KeyLength:  int64(keyBits),
-		NotAfter:   expire.Format("2006-01-02 15:04:05"),
-		NotBefore:  now.Format("2006-01-02 15:04:05"),
-		CreateTime: now.Format("2006-01-02 15:04:05"),
+		CN:           commonName,
+		Usage:        int64(usage),
+		Cert:         string(cert.CertPEM),
+		Key:          string(cert.KeyPEM),
+		Algorithm:    string(keyType),
+		KeyLength:    int64(keyBits),
+		NotAfter:     expire.Format("2006-01-02 15:04:05"),
+		NotBefore:    now.Format("2006-01-02 15:04:05"),
+		CreateTime:   now.Format("2006-01-02 15:04:05"),
+		SerialNumber: fmt.Sprintf("%x", tmpl.SerialNumber),
 	}, nil
 }

--- a/backend/internal/private_ca/ocsp.go
+++ b/backend/internal/private_ca/ocsp.go
@@ -1,0 +1,210 @@
+package private_ca
+
+import (
+	"crypto"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/crypto/ocsp"
+)
+
+// HandleOCSP 处理 OCSP 请求（GET/POST），无需登录。
+// GET:  /v1/private_ca/public/ocsp/<base64url-der>
+// POST: body 为 DER 编码的 OCSPRequest
+func HandleOCSP(c *gin.Context) {
+	var reqDER []byte
+	var err error
+
+	switch c.Request.Method {
+	case http.MethodPost:
+		reqDER, err = io.ReadAll(io.LimitReader(c.Request.Body, 1<<20))
+		if err != nil {
+			c.Data(http.StatusBadRequest, "application/ocsp-response", ocsp.InternalErrorErrorResponse)
+			return
+		}
+	case http.MethodGet:
+		raw := c.Param("payload")
+		raw = strings.TrimPrefix(raw, "/")
+		if raw == "" {
+			raw = c.Query("b64")
+		}
+		if raw == "" {
+			c.Data(http.StatusBadRequest, "application/ocsp-response", ocsp.MalformedRequestErrorResponse)
+			return
+		}
+		reqDER, err = decodeOCSPPayload(raw)
+		if err != nil {
+			c.Data(http.StatusBadRequest, "application/ocsp-response", ocsp.MalformedRequestErrorResponse)
+			return
+		}
+	default:
+		c.Status(http.StatusMethodNotAllowed)
+		return
+	}
+
+	respDER, err := BuildOCSPResponse(reqDER)
+	if err != nil {
+		c.Data(http.StatusOK, "application/ocsp-response", ocsp.InternalErrorErrorResponse)
+		return
+	}
+	c.Header("Cache-Control", "max-age=3600")
+	c.Data(http.StatusOK, "application/ocsp-response", respDER)
+}
+
+func decodeOCSPPayload(raw string) ([]byte, error) {
+	raw = strings.ReplaceAll(raw, "%2B", "+")
+	raw = strings.ReplaceAll(raw, "%2F", "/")
+	raw = strings.ReplaceAll(raw, "%3D", "=")
+	raw = strings.ReplaceAll(raw, "%2b", "+")
+	raw = strings.ReplaceAll(raw, "%2f", "/")
+	raw = strings.ReplaceAll(raw, "%3d", "=")
+	// base64url → base64
+	raw = strings.ReplaceAll(raw, "-", "+")
+	raw = strings.ReplaceAll(raw, "_", "/")
+	for len(raw)%4 != 0 {
+		raw += "="
+	}
+	return base64.StdEncoding.DecodeString(raw)
+}
+
+// BuildOCSPResponse 根据 DER 请求生成签名的 OCSP 响应。
+func BuildOCSPResponse(reqDER []byte) ([]byte, error) {
+	req, err := ocsp.ParseRequest(reqDER)
+	if err != nil {
+		return ocsp.MalformedRequestErrorResponse, nil
+	}
+	if req.SerialNumber == nil {
+		return ocsp.MalformedRequestErrorResponse, nil
+	}
+
+	leaf, caRow, err := findLeafBySerial(req.SerialNumber)
+	if err != nil || leaf == nil || caRow == nil {
+		return ocsp.UnauthorizedErrorResponse, nil
+	}
+
+	algorithm, _ := caRow["algorithm"].(string)
+	if algorithm == "sm2" {
+		return ocsp.InternalErrorErrorResponse, nil
+	}
+
+	issuerObj, err := NewCertificateFromPEMStandard(
+		[]byte(fmt.Sprint(caRow["cert"])),
+		[]byte(fmt.Sprint(caRow["key"])),
+		KeyType(algorithm),
+	)
+	if err != nil || issuerObj.Cert == nil {
+		return ocsp.InternalErrorErrorResponse, nil
+	}
+	signer, ok := issuerObj.Key.(crypto.Signer)
+	if !ok {
+		return ocsp.InternalErrorErrorResponse, nil
+	}
+
+	status := ocsp.Good
+	var revokedAt time.Time
+	reason := 0
+	if st, _ := leaf["status"].(string); st == LeafStatusRevoked {
+		status = ocsp.Revoked
+		revokedAt = time.Now()
+		if v, ok := leaf["revoked_at"].(string); ok && v != "" {
+			if t, e := time.Parse("2006-01-02 15:04:05", v); e == nil {
+				revokedAt = t
+			}
+		}
+		reason = parseRevokeReasonCode(leaf["revoke_reason"])
+		if reason < 0 {
+			reason = 0
+		}
+	}
+
+	now := time.Now()
+	template := ocsp.Response{
+		Status:           status,
+		SerialNumber:     req.SerialNumber,
+		ThisUpdate:       now.Add(-time.Minute),
+		NextUpdate:       now.Add(1 * time.Hour),
+		RevokedAt:        revokedAt,
+		RevocationReason: reason,
+		Certificate:      issuerObj.Cert,
+	}
+
+	return ocsp.CreateResponse(issuerObj.Cert, issuerObj.Cert, template, signer)
+}
+
+func findLeafBySerial(serial *big.Int) (leaf map[string]any, ca map[string]any, err error) {
+	if serial == nil {
+		return nil, nil, fmt.Errorf("nil serial")
+	}
+	s, err := GetSqlite()
+	if err != nil {
+		return nil, nil, err
+	}
+	defer s.Close()
+	s.TableName = "leaf"
+
+	hexSN := strings.ToLower(hex.EncodeToString(serial.Bytes()))
+	hexSN = strings.TrimLeft(hexSN, "0")
+	if hexSN == "" {
+		hexSN = "0"
+	}
+	decSN := serial.String()
+
+	rows, err := s.Where("lower(serial_number)=? or serial_number=? or serial_number=?", []interface{}{hexSN, hexSN, decSN}).Select()
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(rows) == 0 {
+		all, err := s.Where("1=1", []interface{}{}).Select()
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, r := range all {
+			sn, e := resolveLeafSerial(r)
+			if e != nil || sn == nil {
+				continue
+			}
+			if sn.Cmp(serial) == 0 {
+				rows = []map[string]any{r}
+				break
+			}
+		}
+	}
+	if len(rows) == 0 {
+		return nil, nil, fmt.Errorf("leaf not found")
+	}
+	leaf = rows[0]
+	caId, ok := toInt64(leaf["ca_id"])
+	if !ok {
+		return leaf, nil, fmt.Errorf("bad ca_id")
+	}
+	s.TableName = "ca"
+	cas, err := s.Where("id=?", []interface{}{caId}).Select()
+	if err != nil || len(cas) == 0 {
+		return leaf, nil, fmt.Errorf("ca not found")
+	}
+	return leaf, cas[0], nil
+}
+
+func toInt64(v any) (int64, bool) {
+	switch t := v.(type) {
+	case int64:
+		return t, true
+	case int:
+		return int64(t), true
+	case float64:
+		return int64(t), true
+	case string:
+		var n int64
+		_, err := fmt.Sscan(t, &n)
+		return n, err == nil
+	default:
+		return 0, false
+	}
+}

--- a/backend/internal/private_ca/private_ca.go
+++ b/backend/internal/private_ca/private_ca.go
@@ -4,6 +4,7 @@ import (
 	"ALLinSSL/backend/public"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -194,7 +195,7 @@ func CreateLeafCert(caId, usage, keyBits, validDays int64, cn, san string) (*Lea
 		issuerObj, err = NewCertificateFromPEMStandard([]byte(cert), []byte(key), KeyType(keyType))
 
 	}
-	leafObj, err := GenerateLeafCertificate(cn, sans, issuerObj, KeyType(keyType), int(usage), int(keyBits), int(validDays))
+	leafObj, err := GenerateLeafCertificate(cn, sans, issuerObj, KeyType(keyType), int(usage), int(keyBits), int(validDays), caId)
 	if err != nil {
 		return nil, err
 	}
@@ -202,6 +203,7 @@ func CreateLeafCert(caId, usage, keyBits, validDays int64, cn, san string) (*Lea
 	// 保存到数据库
 	leafObj.SAN = san
 	leafObj.CaId = caId
+	leafObj.Status = LeafStatusNormal
 	insertData := public.StructToMap(leafObj, true)
 	_, err = s.Insert(insertData)
 	if err != nil {
@@ -259,10 +261,33 @@ func ListLeafCerts(caId int64, search string, p, limit int64) ([]map[string]inte
 		count = countResult[0]["count"].(int64)
 	}
 
+	// 兼容旧数据：无 status 字段时视为正常
+	for _, v := range data {
+		status, _ := v["status"].(string)
+		if status == "" {
+			v["status"] = LeafStatusNormal
+		}
+	}
+
 	return data, int(count), nil
 }
 
 func DeleteLeafCert(id int64) error {
+	return DeleteLeafCerts(fmt.Sprintf("%d", id))
+}
+
+// DeleteLeafCerts 支持逗号分隔的多个叶子证书 ID 批量删除。
+func DeleteLeafCerts(ids string) error {
+	ids = strings.TrimSpace(ids)
+	if ids == "" {
+		return fmt.Errorf("ID不能为空")
+	}
+	// 仅允许数字和逗号，防止 SQL 注入
+	for _, ch := range ids {
+		if (ch < '0' || ch > '9') && ch != ',' && ch != ' ' {
+			return fmt.Errorf("ID格式无效")
+		}
+	}
 	s, err := GetSqlite()
 	if err != nil {
 		return err
@@ -270,9 +295,93 @@ func DeleteLeafCert(id int64) error {
 	defer s.Close()
 	s.TableName = "leaf"
 
-	_, err = s.Where("id=?", []interface{}{id}).Delete()
+	_, err = s.Where("id in ("+ids+")", []interface{}{}).Delete()
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+// validRevokeReasons RFC 5280 允许的吊销原因码
+var validRevokeReasons = map[int]string{
+	RevokeReasonUnspecified:          "unspecified",
+	RevokeReasonKeyCompromise:        "keyCompromise",
+	RevokeReasonCACompromise:         "cACompromise",
+	RevokeReasonAffiliationChanged:   "affiliationChanged",
+	RevokeReasonSuperseded:           "superseded",
+	RevokeReasonCessationOfOperation: "cessationOfOperation",
+	RevokeReasonCertificateHold:      "certificateHold",
+	RevokeReasonRemoveFromCRL:        "removeFromCRL",
+	RevokeReasonPrivilegeWithdrawn:   "privilegeWithdrawn",
+	RevokeReasonAACompromise:         "aACompromise",
+}
+
+// RevokeLeafCert 吊销私有 CA 签发的叶子证书。
+// reason 使用 RFC 5280 §5.3.1 原因码；reasonNote 为可选备注。
+// 吊销后证书记录保留，状态标记为 revoked，工作流复用会跳过该证书。
+func RevokeLeafCert(id int64, reason int, reasonNote string) error {
+	return RevokeLeafCerts(fmt.Sprintf("%d", id), reason, reasonNote)
+}
+
+// RevokeLeafCerts 支持逗号分隔的多个叶子证书 ID 批量吊销。
+// 已吊销的会跳过；全部无效时返回错误。
+func RevokeLeafCerts(ids string, reason int, reasonNote string) error {
+	ids = strings.TrimSpace(ids)
+	if ids == "" {
+		return fmt.Errorf("证书 ID 无效")
+	}
+	for _, ch := range ids {
+		if (ch < '0' || ch > '9') && ch != ',' && ch != ' ' {
+			return fmt.Errorf("ID格式无效")
+		}
+	}
+	reasonLabel, ok := validRevokeReasons[reason]
+	if !ok {
+		return fmt.Errorf("不支持的吊销原因码: %d", reason)
+	}
+
+	s, err := GetSqlite()
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+	s.TableName = "leaf"
+
+	leafs, err := s.Where("id in ("+ids+")", []interface{}{}).Select()
+	if err != nil {
+		return err
+	}
+	if len(leafs) == 0 {
+		return fmt.Errorf("证书不存在")
+	}
+
+	revokeReason := reasonLabel
+	if reasonNote != "" {
+		revokeReason = reasonLabel + ": " + reasonNote
+	}
+	now := time.Now().Format("2006-01-02 15:04:05")
+	updated := 0
+	skipped := 0
+	for _, leaf := range leafs {
+		if status, _ := leaf["status"].(string); status == LeafStatusRevoked {
+			skipped++
+			continue
+		}
+		_, err = s.Where("id=?", []interface{}{leaf["id"]}).Update(map[string]interface{}{
+			"status":        LeafStatusRevoked,
+			"revoke_reason": revokeReason,
+			"revoked_at":    now,
+		})
+		if err != nil {
+			return fmt.Errorf("吊销证书失败: %v", err)
+		}
+		updated++
+	}
+	if updated == 0 {
+		if skipped > 0 {
+			return fmt.Errorf("所选证书均已吊销，无需重复操作")
+		}
+		return fmt.Errorf("未吊销任何证书")
 	}
 	return nil
 }
@@ -367,13 +476,17 @@ func WorkflowCreateLeafCert(params map[string]any, logger *public.Logger) (map[s
 		}
 	}
 	s.TableName = "leaf"
-	// 获取所有未过期的证书，判断是否有相同的cn和san
-	leafs, err := s.Where("ca_id=? and not_after>? and usage=1", []interface{}{caId, time.Now().Format("2006-01-02 15:04:05")}).Select()
+	// 获取所有未过期且未吊销的证书，判断是否有相同的cn和san
+	leafs, err := s.Where("ca_id=? and not_after>? and usage=1 and (status is null or status=? or status='')", []interface{}{caId, time.Now().Format("2006-01-02 15:04:05"), LeafStatusNormal}).Select()
 	if err != nil {
 		return nil, err
 	}
 	var certificate map[string]any
 	for _, v := range leafs {
+		// 已吊销的证书不可复用
+		if status, _ := v["status"].(string); status == LeafStatusRevoked {
+			continue
+		}
 		// 判断剩余天数是否满足要求
 		if endDay > 0 {
 			notAfter, err := time.Parse("2006-01-02 15:04:05", v["not_after"].(string))

--- a/backend/internal/private_ca/public_url.go
+++ b/backend/internal/private_ca/public_url.go
@@ -1,0 +1,50 @@
+package private_ca
+
+import (
+	"ALLinSSL/backend/public"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// PublicBaseURL 返回用于写入证书扩展的公网可访问基址。
+// 优先读取 settings.public_base_url；未配置时用当前监听端口拼默认值。
+// 示例：https://ca.example.com  或  http://127.0.0.1:20773
+func PublicBaseURL() string {
+	base := strings.TrimSpace(public.GetSettingIgnoreError("public_base_url"))
+	if base != "" {
+		return strings.TrimRight(base, "/")
+	}
+	port := public.Port
+	if port == "" {
+		port = "8888"
+	}
+	scheme := "http"
+	if public.GetSettingIgnoreError("https") == "1" {
+		scheme = "https"
+	}
+	return fmt.Sprintf("%s://127.0.0.1:%s", scheme, port)
+}
+
+// CRLDistributionURL 返回指定 CA 的 CRL 下载地址。
+func CRLDistributionURL(caId int64) string {
+	return fmt.Sprintf("%s/v1/private_ca/public/crl?ca_id=%d", PublicBaseURL(), caId)
+}
+
+// OCSPServerURL 返回 OCSP 应答器地址。
+func OCSPServerURL() string {
+	return fmt.Sprintf("%s/v1/private_ca/public/ocsp", PublicBaseURL())
+}
+
+// ValidatePublicBaseURL 校验配置的基址是否为合法 URL（可选辅助）。
+func ValidatePublicBaseURL(raw string) error {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("public_base_url 无效，请使用完整 URL，例如 https://ca.example.com")
+	}
+	return nil
+}

--- a/backend/internal/private_ca/types.go
+++ b/backend/internal/private_ca/types.go
@@ -71,20 +71,45 @@ type CAConfig struct {
 	ValidDays  int64  `json:"valid_days" form:"valid_days"`
 }
 
+// 叶子证书状态
+const (
+	LeafStatusNormal  = "normal"
+	LeafStatusRevoked = "revoked"
+)
+
+// RFC 5280 §5.3.1 吊销原因码（与 ACME / CRL 保持一致）
+const (
+	RevokeReasonUnspecified          = 0
+	RevokeReasonKeyCompromise        = 1
+	RevokeReasonCACompromise         = 2
+	RevokeReasonAffiliationChanged   = 3
+	RevokeReasonSuperseded           = 4
+	RevokeReasonCessationOfOperation = 5
+	RevokeReasonCertificateHold      = 6
+	// 7 保留
+	RevokeReasonRemoveFromCRL      = 8
+	RevokeReasonPrivilegeWithdrawn = 9
+	RevokeReasonAACompromise       = 10
+)
+
 type LeafCertConfig struct {
-	Id         int64  `json:"id" form:"id"`
-	CaId       int64  `json:"ca_id" form:"ca_id"`
-	CN         string `json:"cn" form:"cn"`
-	SAN        string `json:"san" form:"san"`
-	Usage      int64  `json:"usage" form:"usage"`
-	Cert       string `json:"cert" form:"cert"`
-	Key        string `json:"key" form:"key"`
-	EnCert     string `json:"en_cert" form:"en_cert"`
-	EnKey      string `json:"en_key" form:"en_key"`
-	Algorithm  string `json:"algorithm" form:"algorithm"`
-	KeyLength  int64  `json:"key_length" form:"key_length"`
-	NotAfter   string `json:"not_after" form:"not_after"`
-	NotBefore  string `json:"not_before" form:"not_before"`
-	ValidDays  int64  `json:"valid_days" form:"valid_days"`
-	CreateTime string `json:"create_time" form:"create_time"`
+	Id           int64  `json:"id" form:"id"`
+	CaId         int64  `json:"ca_id" form:"ca_id"`
+	CN           string `json:"cn" form:"cn"`
+	SAN          string `json:"san" form:"san"`
+	Usage        int64  `json:"usage" form:"usage"`
+	Cert         string `json:"cert" form:"cert"`
+	Key          string `json:"key" form:"key"`
+	EnCert       string `json:"en_cert" form:"en_cert"`
+	EnKey        string `json:"en_key" form:"en_key"`
+	Algorithm    string `json:"algorithm" form:"algorithm"`
+	KeyLength    int64  `json:"key_length" form:"key_length"`
+	NotAfter     string `json:"not_after" form:"not_after"`
+	NotBefore    string `json:"not_before" form:"not_before"`
+	ValidDays    int64  `json:"valid_days" form:"valid_days"`
+	CreateTime   string `json:"create_time" form:"create_time"`
+	Status       string `json:"status" form:"status"`
+	RevokeReason string `json:"revoke_reason" form:"revoke_reason"`
+	RevokedAt    string `json:"revoked_at" form:"revoked_at"`
+	SerialNumber string `json:"serial_number" form:"serial_number"`
 }

--- a/backend/internal/setting/setting.go
+++ b/backend/internal/setting/setting.go
@@ -11,19 +11,21 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 )
 
 type Setting struct {
-	Timeout    int    `json:"timeout" form:"timeout"`
-	Secure     string `json:"secure" form:"secure"`
-	Https      string `json:"https" form:"https"`
-	Key        string `json:"key" form:"key"`
-	Cert       string `json:"cert" form:"cert"`
-	Username   string `json:"username" form:"username"`
-	Password   string `json:"password" form:"password"`
-	PluginPath string `json:"plugin_path" form:"plugin_path"`
+	Timeout       int    `json:"timeout" form:"timeout"`
+	Secure        string `json:"secure" form:"secure"`
+	Https         string `json:"https" form:"https"`
+	Key           string `json:"key" form:"key"`
+	Cert          string `json:"cert" form:"cert"`
+	Username      string `json:"username" form:"username"`
+	Password      string `json:"password" form:"password"`
+	PluginPath    string `json:"plugin_path" form:"plugin_path"`
+	PublicBaseURL string `json:"public_base_url" form:"public_base_url"`
 }
 
 func Get() (Setting, error) {
@@ -59,6 +61,7 @@ func Get() (Setting, error) {
 	username := data[0]["username"].(string)
 	setting.Username = username
 	setting.PluginPath = public.GetSettingIgnoreError("plugin_dir")
+	setting.PublicBaseURL = public.GetSettingIgnoreError("public_base_url")
 	return setting, nil
 }
 
@@ -116,6 +119,30 @@ func Save(setting *Setting) error {
 	}
 	if setting.PluginPath != "" && setting.PluginPath != public.GetSettingIgnoreError("plugin_dir") {
 		public.UpdateSetting("plugin_dir", setting.PluginPath)
+	}
+	// 公网基址：写入 CDP/OCSP 扩展与公开下载链接
+	if setting.PublicBaseURL != public.GetSettingIgnoreError("public_base_url") {
+		base := strings.TrimSpace(setting.PublicBaseURL)
+		if base != "" {
+			if !strings.HasPrefix(base, "http://") && !strings.HasPrefix(base, "https://") {
+				return fmt.Errorf("public_base_url 需以 http:// 或 https:// 开头")
+			}
+			base = strings.TrimRight(base, "/")
+		}
+		// 无记录则插入
+		if public.GetSettingIgnoreError("public_base_url") == "" && base != "" {
+			s.TableName = "settings"
+			now := time.Now().Format("2006-01-02 15:04:05")
+			_, _ = s.Insert(map[string]interface{}{
+				"key":         "public_base_url",
+				"value":       base,
+				"create_time": now,
+				"update_time": now,
+				"active":      1,
+			})
+		} else {
+			_ = public.UpdateSetting("public_base_url", base)
+		}
 	}
 	if setting.Https != "" {
 		if setting.Https == "1" {

--- a/backend/middleware/auth.go
+++ b/backend/middleware/auth.go
@@ -29,6 +29,10 @@ func SessionAuthMiddleware() gin.HandlerFunc {
 
 		routePath := c.Request.URL.Path
 		method := c.Request.Method
+			if isPrivateCAPublicPath(routePath, method) {
+				c.Next()
+				return
+			}
 		paths := strings.Split(strings.TrimPrefix(routePath, "/"), "/")
 		session := sessions.Default(c)
 		now := time.Now()
@@ -183,3 +187,17 @@ func generateSignature(timestamp, apiKey string) string {
 	signMd5Hex := strings.ToLower(hex.EncodeToString(signMd5[:]))
 	return signMd5Hex
 }
+
+// isPrivateCAPublicPath CRL/OCSP 公开端点，无需登录。
+func isPrivateCAPublicPath(path, method string) bool {
+	if !strings.HasPrefix(path, "/v1/private_ca/public/") {
+		return false
+	}
+	switch method {
+	case "GET", "POST":
+		return true
+	default:
+		return false
+	}
+}
+

--- a/backend/migrations/init.go
+++ b/backend/migrations/init.go
@@ -74,25 +74,30 @@ func init() {
 	
 	create table IF NOT EXISTS cert
 	(
-	    id          integer not null
+	    id            integer not null
 	        constraint cert_pk
 	            primary key autoincrement,
-	    source      TEXT    not null,
-	    sha256      TEXT,
-	    history_id  TEXT,
-	    key         TEXT    not null,
-	    cert        TEXT    not null,
-	    issuer_cert integer,
-	    domains     TEXT    not null,
-	    create_time TEXT,
-	    update_time TEXT,
-	    issuer      TEXT    not null,
-	    start_time  TEXT,
-	    end_time    TEXT,
-	    end_day     TEXT,
-	    workflow_id TEXT
+	    source        TEXT    not null,
+	    sha256        TEXT,
+	    history_id    TEXT,
+	    key           TEXT    not null,
+	    cert          TEXT    not null,
+	    issuer_cert   integer,
+	    domains       TEXT    not null,
+	    create_time   TEXT,
+	    update_time   TEXT,
+	    issuer        TEXT    not null,
+	    start_time    TEXT,
+	    end_time      TEXT,
+	    end_day       TEXT,
+	    workflow_id   TEXT,
+	    status        TEXT    default 'normal' not null,
+	    revoke_reason TEXT    default '' not null,
+	    revoked_at    TEXT,
+	    acme_email    TEXT    default '' not null,
+	    acme_ca       TEXT    default '' not null
 	);
-	
+
 	create table IF NOT EXISTS report
 	(
 	    id          integer not null
@@ -145,6 +150,14 @@ func init() {
 	);
 
 	`)
+	// 为已有 cert 表补充吊销相关字段
+	ensureColumn(db, "cert", "status", "TEXT default 'normal' not null")
+	ensureColumn(db, "cert", "revoke_reason", "TEXT default '' not null")
+	ensureColumn(db, "cert", "revoked_at", "TEXT")
+	ensureColumn(db, "cert", "acme_email", "TEXT default '' not null")
+	ensureColumn(db, "cert", "acme_ca", "TEXT default '' not null")
+	_, _ = db.Exec(`UPDATE cert SET status = 'normal' WHERE status IS NULL OR status = ''`)
+
 	insertDefaultData(db, "access_type", `
 	INSERT INTO access_type (name, type) VALUES ('aliyun', 'dns');
 	INSERT INTO access_type (name, type) VALUES ('tencentcloud', 'dns');
@@ -397,7 +410,7 @@ create table monitor
 	// 创建表
 	_, err = dbPrivateCa.Exec(`
 	PRAGMA journal_mode=WAL;
-	create table ca
+	create table IF NOT EXISTS ca
 	(
 		id          integer         not null
 			constraint ca_pk
@@ -417,32 +430,66 @@ create table monitor
 		not_after   TEXT            not null,
 		create_time TEXT            not null
 	);
-	create index ca_root_id_index
+	create index IF NOT EXISTS ca_root_id_index
 		on ca (root_id);
-	create table leaf
+	create table IF NOT EXISTS leaf
 	(
-		id          integer not null
+		id            integer not null
 			constraint leaf_pk
 				primary key autoincrement,
-		ca_id       integer not null,
-		cn          TEXT    not null,
-		san         TEXT    not null,
-		usage       integer not null,
-		cert        TEXT    not null,
-		key         TEXT    not null,
-		en_cert     TEXT,
-		en_key      TEXT,
-		algorithm   TEXT    not null,
-		key_length  integer,
-		not_before  TEXT    not null,
-		not_after   TEXT    not null,
-		create_time TEXT    not null
+		ca_id         integer not null,
+		cn            TEXT    not null,
+		san           TEXT    not null,
+		usage         integer not null,
+		cert          TEXT    not null,
+		key           TEXT    not null,
+		en_cert       TEXT,
+		en_key        TEXT,
+		algorithm     TEXT    not null,
+		key_length    integer,
+		not_before    TEXT    not null,
+		not_after     TEXT    not null,
+		create_time   TEXT    not null,
+		status        TEXT    default 'normal' not null,
+		revoke_reason TEXT    default '' not null,
+		revoked_at    TEXT,
+		serial_number TEXT    default '' not null
 	);
-	
-	create index leaf_ca_id_index
+
+	create index IF NOT EXISTS leaf_ca_id_index
 		on leaf (ca_id);
 `)
+	if err == nil {
+		ensureColumn(dbPrivateCa, "leaf", "status", "TEXT default 'normal' not null")
+		ensureColumn(dbPrivateCa, "leaf", "revoke_reason", "TEXT default '' not null")
+		ensureColumn(dbPrivateCa, "leaf", "revoked_at", "TEXT")
+		ensureColumn(dbPrivateCa, "leaf", "serial_number", "TEXT default '' not null")
+		// 兼容旧数据：已有叶子证书默认视为正常
+		_, _ = dbPrivateCa.Exec(`UPDATE leaf SET status = 'normal' WHERE status IS NULL OR status = ''`)
+	}
+}
 
+// ensureColumn 为已存在的表补充缺失字段，兼容旧版本数据库。
+func ensureColumn(db *sql.DB, table, column, definition string) {
+	rows, err := db.Query(fmt.Sprintf("PRAGMA table_info(%s)", table))
+	if err != nil {
+		return
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var notnull, pk int
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			return
+		}
+		if name == column {
+			return
+		}
+	}
+	_, _ = db.Exec(fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s", table, column, definition))
 }
 
 func insertDefaultData(db *sql.DB, table, insertSQL string) {

--- a/backend/route/route.go
+++ b/backend/route/route.go
@@ -84,6 +84,8 @@ func Register(r *gin.Engine) {
 		cert.POST("/get_list", api.GetCertList)
 		cert.POST("/upload_cert", api.UploadCert)
 		cert.POST("/del_cert", api.DelCert)
+		cert.POST("/revoke_cert", api.RevokeCert)
+		cert.POST("/backfill_acme", api.BackfillACME)
 		cert.GET("/download", api.DownloadCert)
 	}
 	report := v1.Group("/report")
@@ -118,6 +120,13 @@ func Register(r *gin.Engine) {
 		privateCa.POST("/create_leaf_cert", private_ca.CreateLeafCert)
 		privateCa.POST("/get_leaf_cert_list", private_ca.GetLeafCertList)
 		privateCa.POST("/del_leaf_cert", private_ca.DeleteLeafCert)
+		privateCa.POST("/revoke_leaf_cert", private_ca.RevokeLeafCert)
+		privateCa.GET("/download_crl", private_ca.DownloadCRL)
+		// 公开端点：无需登录（auth middleware 白名单）
+		privateCa.GET("/public/crl", private_ca.DownloadCRLPublic)
+		privateCa.GET("/public/ocsp/*payload", private_ca.HandleOCSP)
+		privateCa.POST("/public/ocsp", private_ca.HandleOCSP)
+		privateCa.POST("/public/ocsp/*payload", private_ca.HandleOCSP)
 		privateCa.GET("/download_cert", private_ca.DownloadCert)
 	}
 

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"ALLinSSL/backend/internal/cert"
 	"ALLinSSL/backend/middleware"
 	"ALLinSSL/backend/public"
 	"ALLinSSL/backend/route"
@@ -21,6 +22,10 @@ import (
 func Run() error {
 	public.ReloadConfig()
 	public.InitLogger(public.LogPath)
+	// startup: backfill ACME account metadata for legacy certs
+	if n, err := cert.BackfillACMEMetadata(); err == nil && n > 0 {
+		fmt.Printf("backfilled ACME metadata for %d cert(s)\n", n)
+	}
 	defer public.CloseLogger()
 	r := gin.Default()
 

--- a/frontend/apps/allin-ssl/src/api/ca.ts
+++ b/frontend/apps/allin-ssl/src/api/ca.ts
@@ -18,6 +18,8 @@ import type {
 	GetLeafCertListResponse,
 	DeleteLeafCertParams,
 	DeleteLeafCertResponse,
+	RevokeLeafCertParams,
+	RevokeLeafCertResponse,
 } from '@/types/ca'
 
 import { useApi } from "@api/index";
@@ -77,3 +79,11 @@ export const getLeafCertList = (params?: GetLeafCertListParams): useAxiosReturn<
  */
 export const deleteLeafCert = (params?: DeleteLeafCertParams): useAxiosReturn<DeleteLeafCertResponse, DeleteLeafCertParams> =>
 	useApi<DeleteLeafCertResponse, DeleteLeafCertParams>('/v1/private_ca/del_leaf_cert', params)
+
+/**
+ * @description 吊销叶子证书
+ * @param {RevokeLeafCertParams} [params] 请求参数
+ * @returns {useAxiosReturn<RevokeLeafCertResponse, RevokeLeafCertParams>} 吊销叶子证书的组合式 API 调用封装。包含响应数据、加载状态及执行函数。
+ */
+export const revokeLeafCert = (params?: RevokeLeafCertParams): useAxiosReturn<RevokeLeafCertResponse, RevokeLeafCertParams> =>
+	useApi<RevokeLeafCertResponse, RevokeLeafCertParams>('/v1/private_ca/revoke_leaf_cert', params)

--- a/frontend/apps/allin-ssl/src/api/cert.ts
+++ b/frontend/apps/allin-ssl/src/api/cert.ts
@@ -14,6 +14,8 @@ import type {
 	DownloadCertResponse, // Ensuring this type is imported
 	UploadCertParams,
 	UploadCertResponse,
+	RevokeCertParams,
+	RevokeCertResponse,
 } from '@/types/cert' // Path alias and sorted types
 
 // Relative internal imports
@@ -59,3 +61,11 @@ export const deleteCert = (params?: DeleteCertParams): useAxiosReturn<DeleteCert
 export const downloadCert = (params?: DownloadCertParams): Promise<AxiosResponse<DownloadCertResponse>> => {
 	return axios.get<DownloadCertResponse>('/v1/cert/download', { params })
 }
+
+/**
+ * @description 吊销证书（ACME）
+ * @param {RevokeCertParams} [params] 请求参数
+ * @returns {useAxiosReturn<RevokeCertResponse, RevokeCertParams>} 吊销证书的组合式 API 调用封装。
+ */
+export const revokeCert = (params?: RevokeCertParams): useAxiosReturn<RevokeCertResponse, RevokeCertParams> =>
+	useApi<RevokeCertResponse, RevokeCertParams>('/v1/cert/revoke_cert', params)

--- a/frontend/apps/allin-ssl/src/types/ca.d.ts
+++ b/frontend/apps/allin-ssl/src/types/ca.d.ts
@@ -248,3 +248,24 @@ export interface DeleteLeafCertResponse {
 	message: string;
 	status: boolean;
 }
+
+/**
+ * 吊销叶子证书请求参数
+ */
+export interface RevokeLeafCertParams {
+	/** 叶子证书ID */
+	id: string;
+	/** RFC 5280 吊销原因码，默认 0 (unspecified) */
+	reason?: number | string;
+	/** 可选备注 */
+	reason_note?: string;
+}
+
+/**
+ * 吊销叶子证书响应
+ */
+export interface RevokeLeafCertResponse {
+	code: number;
+	message: string;
+	status: boolean;
+}

--- a/frontend/apps/allin-ssl/src/types/cert.d.ts
+++ b/frontend/apps/allin-ssl/src/types/cert.d.ts
@@ -25,6 +25,12 @@ export interface CertItem {
 	start_time: string
 	update_time: string
 	workflow_id: string
+	/** normal | revoked */
+	status?: string
+	revoke_reason?: string
+	revoked_at?: string
+	acme_email?: string
+	acme_ca?: string
 }
 
 /** 证书列表响应 */
@@ -120,4 +126,16 @@ export interface FreeProductItem {
 	valid_days: number
 	desc?: string
 	features: string[]
+}
+
+/** 吊销证书请求参数 */
+export interface RevokeCertParams {
+	id: string
+	reason?: number | string
+	reason_note?: string
+}
+
+/** 吊销证书响应 */
+export interface RevokeCertResponse extends AxiosResponseData {
+	data: null
 }

--- a/frontend/apps/allin-ssl/src/types/setting.d.ts
+++ b/frontend/apps/allin-ssl/src/types/setting.d.ts
@@ -14,6 +14,9 @@ export interface SystemSetting {
 	cert: string // 证书
 	username: string // 用户
 	password: string // 密码
+	plugin_path?: string // 插件目录
+	/** 公网访问基址，用于私有 CA 的 CRL/OCSP URL（如 https://ca.example.com） */
+	public_base_url?: string
 }
 
 /** 获取设置响应 */

--- a/frontend/apps/allin-ssl/src/views/certManage/index.tsx
+++ b/frontend/apps/allin-ssl/src/views/certManage/index.tsx
@@ -9,6 +9,7 @@ import EmptyState from '@components/TableEmptyState'
 
 const batchActionOptions = [
 	{ label: '删除', value: 'delete' },
+	{ label: '吊销', value: 'revoke' },
 ]
 
 /**

--- a/frontend/apps/allin-ssl/src/views/certManage/useController.tsx
+++ b/frontend/apps/allin-ssl/src/views/certManage/useController.tsx
@@ -1,4 +1,4 @@
-import { NButton, NSpace, NTag, type DataTableColumns } from 'naive-ui'
+import { NButton, NSpace, NTag, NSelect, type DataTableColumns } from 'naive-ui'
 import {
 	useModal,
 	useTable,
@@ -18,9 +18,22 @@ import { useStore } from './useStore'
 
 import type { CertItem, CertListParams } from '@/types/cert'
 
+
+const REVOKE_REASON_OPTIONS = [
+  { label: '未指定 (unspecified)', value: 0 },
+  { label: '密钥泄露 (keyCompromise)', value: 1 },
+  { label: 'CA 泄露 (cACompromise)', value: 2 },
+  { label: '从属关系变更 (affiliationChanged)', value: 3 },
+  { label: '被取代 (superseded)', value: 4 },
+  { label: '停止运营 (cessationOfOperation)', value: 5 },
+  { label: '证书挂起 (certificateHold)', value: 6 },
+  { label: '权限撤销 (privilegeWithdrawn)', value: 9 },
+  { label: 'AA 泄露 (aACompromise)', value: 10 },
+]
+
 const { handleError } = useError()
 const { useFormTextarea } = useFormHooks()
-const { fetchCertList, downloadExistingCert, deleteExistingCert, uploadNewCert, uploadForm, resetUploadForm, deleteBatchCerts } =
+const { fetchCertList, downloadExistingCert, deleteExistingCert, revokeExistingCert, revokeBatchCerts, uploadNewCert, uploadForm, resetUploadForm, deleteBatchCerts } =
 	useStore()
 const { confirm } = useModalHooks()
 /**
@@ -79,11 +92,44 @@ export const useController = () => {
 		if (batchActionRef.value === 'delete') {
 			useDialog({
 				title: '批量删除证书',
-				content: `确定要删除选中的 ${checkedRowKeysRef.value.length} 个证书吗？`,
+				content: `确定要删除选中的 ${checkedRowKeysRef.value.length} 个证书吗？此操作不可恢复。`,
 				onPositiveClick: async () => {
 					try {
 						await deleteBatchCerts(checkedRowKeysRef.value)
 						checkedRowKeysRef.value = []
+						useMessage().success('批量删除成功')
+						await fetch()
+					} catch (error) {
+						handleError(error)
+					}
+				},
+			})
+			return
+		}
+		if (batchActionRef.value === 'revoke') {
+			const reasonRef = ref<number>(0)
+			useDialog({
+				title: '批量吊销证书',
+				content: () => (
+					<div class="flex flex-col gap-3">
+						<div>确定要向 CA 吊销选中的 {checkedRowKeysRef.value.length} 个证书吗？上传证书会失败并跳过，此操作不可恢复。</div>
+						<div>
+							<div class="mb-1 text-sm text-gray-500">吊销原因</div>
+							<NSelect
+								value={reasonRef.value}
+								options={REVOKE_REASON_OPTIONS}
+								onUpdateValue={(v: number) => {
+									reasonRef.value = v
+								}}
+							/>
+						</div>
+					</div>
+				),
+				onPositiveClick: async () => {
+					try {
+						await revokeBatchCerts(checkedRowKeysRef.value, reasonRef.value)
+						checkedRowKeysRef.value = []
+						useMessage().success('批量吊销完成')
 						await fetch()
 					} catch (error) {
 						handleError(error)
@@ -93,11 +139,7 @@ export const useController = () => {
 		}
 	}
 
-	/**
-	 * @description 创建表格列配置
-	 * @returns {DataTableColumns<CertItem>} 返回表格列配置数组
-	 */
-	const createColumns = (): DataTableColumns<CertItem> => [
+		const createColumns = (): DataTableColumns<CertItem> => [
 		{
 			type: 'selection',
 		},
@@ -142,7 +184,14 @@ export const useController = () => {
 				return true
 			},
 			render: (row: CertItem) => {
-				const endDay = calculateRemainingDays(row)
+				if (row.status === 'revoked') {
+						return (
+							<NTag round type="error" size="small">
+								已吊销
+							</NTag>
+						)
+					}
+					const endDay = calculateRemainingDays(row)
 
 				// 如果无法计算剩余天数，显示获取失败
 				if (endDay === null) {
@@ -195,7 +244,12 @@ export const useController = () => {
 					<NButton size="tiny" strong secondary type="primary" class="table-action-btn" onClick={() => downloadExistingCert(row.id.toString())}>
 						{$t('t_25_1745227838080')}
 					</NButton>
-					<NButton size="tiny" strong secondary type="error" class="table-action-btn-danger" onClick={() => handleDeleteCert(row)}>
+					{row.source !== 'upload' && row.status !== 'revoked' && (
+							<NButton size="tiny" strong secondary type="warning" class="table-action-btn" onClick={() => handleRevokeCert(row)}>
+								吊销
+							</NButton>
+						)}
+						<NButton size="tiny" strong secondary type="error" class="table-action-btn-danger" onClick={() => handleDeleteCert(row)}>
 						{$t('t_12_1745215914312')}
 					</NButton>
 				</NSpace>
@@ -297,7 +351,50 @@ export const useController = () => {
 	 * @description 打开查看证书弹窗
 	 * @param {CertItem} cert - 证书对象
 	 */
-	const openViewModal = (cert: CertItem) => {
+	
+		/**
+		 * @description 吊销证书（ACME）
+		 */
+		const handleRevokeCert = async (cert: CertItem) => {
+			if (cert.source === 'upload') {
+				useMessage().warning('上传证书无法通过 ACME 吊销')
+				return
+			}
+			if (cert.status === 'revoked') {
+				useMessage().warning('证书已吊销')
+				return
+			}
+			const reasonRef = ref<number>(0)
+			useDialog({
+				title: '确认吊销',
+				content: () => (
+					<div class="flex flex-col gap-3">
+						<div>确定要向 CA 吊销证书 "{cert.domains}" 吗？吊销后证书将立即失效，此操作不可恢复。</div>
+						<div>
+							<div class="mb-1 text-sm text-gray-500">吊销原因</div>
+							<NSelect
+								value={reasonRef.value}
+								options={REVOKE_REASON_OPTIONS}
+								onUpdateValue={(v: number) => {
+									reasonRef.value = v
+								}}
+							/>
+						</div>
+					</div>
+				),
+				onPositiveClick: async () => {
+					try {
+						await revokeExistingCert(cert.id.toString(), reasonRef.value)
+						useMessage().success('吊销成功')
+						await fetch()
+					} catch (error) {
+						handleError(error)
+					}
+				},
+			})
+		}
+
+		const openViewModal = (cert: CertItem) => {
 		useModal({
 			title: '查看证书信息',
 			area: 600,

--- a/frontend/apps/allin-ssl/src/views/certManage/useStore.tsx
+++ b/frontend/apps/allin-ssl/src/views/certManage/useStore.tsx
@@ -1,5 +1,5 @@
 import { defineStore, storeToRefs } from 'pinia'
-import { getCertList, uploadCert, deleteCert } from '@/api/cert'
+import { getCertList, uploadCert, deleteCert, revokeCert } from '@/api/cert'
 import { useError } from '@baota/hooks/error'
 import { $t } from '@locales/index'
 import type { CertItem, UploadCertParams, CertListParams } from '@/types/cert'
@@ -96,6 +96,40 @@ export const useCertManageStore = defineStore('cert-manage-store', () => {
 	 * @param {string[]} ids - 证书ID数组
 	 * @returns {Promise<void>}
 	 */
+
+	/**
+	 * 吊销证书
+	 * @description 通过 ACME 向 CA 吊销指定证书
+	 * @param {string} id - 证书ID
+	 */
+	const revokeExistingCert = async (id: string, reason: number = 0, reason_note: string = '') => {
+		try {
+			const { message, fetch } = revokeCert({ id, reason, reason_note })
+			message.value = true
+			await fetch()
+		} catch (error) {
+			handleError(error)
+			throw error
+		}
+	}
+
+	
+	/**
+	 * 批量吊销证书
+	 * @description 通过 ACME 批量吊销选中证书
+	 */
+	const revokeBatchCerts = async (ids: any, reason: number = 0) => {
+		try {
+			const ids_param = Array.isArray(ids) ? ids.join(',') : String(ids)
+			const { message, fetch } = revokeCert({ id: ids_param, reason })
+			message.value = true
+			await fetch()
+		} catch (error) {
+			handleError(error)
+			throw error
+		}
+	}
+
 	const deleteBatchCerts = async (ids: any) => {
 		try {
 			const ids_param = ids.join(',')
@@ -126,6 +160,8 @@ export const useCertManageStore = defineStore('cert-manage-store', () => {
 		downloadExistingCert,
 		uploadNewCert,
 		deleteExistingCert,
+		revokeExistingCert,
+		revokeBatchCerts,
 		deleteBatchCerts,
 		resetUploadForm,
 	}

--- a/frontend/apps/allin-ssl/src/views/privateCaCert/index.tsx
+++ b/frontend/apps/allin-ssl/src/views/privateCaCert/index.tsx
@@ -7,17 +7,26 @@ import BaseComponent from "@components/BaseLayout";
 import EmptyState from "@components/TableEmptyState";
 import { useStore } from "./useStore";
 
+const batchActionOptions = [
+	{ label: "删除", value: "delete" },
+	{ label: "吊销", value: "revoke" },
+];
+
 export default defineComponent({
 	name: "PrivateCaCert",
 	setup() {
-		const { 
-			TableComponent, 
-			PageComponent, 
-			SearchComponent,
-			getRowClassName,
-			openCreateLeafCertModal,
-			handleCaIdChange,
-		} = useController();
+		const {
+				TableComponent,
+				PageComponent,
+				SearchComponent,
+				getRowClassName,
+				openCreateLeafCertModal,
+				handleCaIdChange,
+				checkedRowKeysRef,
+				handleCheck,
+				batchActionRef,
+				handleBatchAction,
+			} = useController();
 		const { intermediateCaList, getIntermediateCaList } = useStore();
 
 		const cssVar = useThemeCssVar(['contentPadding', 'borderColor', 'headerHeight', 'iconColorHover']);
@@ -68,6 +77,9 @@ export default defineComponent({
                   <TableComponent
                     size="medium"
                     rowClassName={getRowClassName}
+                    checkedRowKeys={checkedRowKeysRef.value}
+                    onUpdateCheckedRowKeys={handleCheck}
+                    rowKey={(row: any) => row.id.toString()}
                     v-slots={{
                       empty: () => (
                         <EmptyState
@@ -82,6 +94,28 @@ export default defineComponent({
               footerRight: () => (
                 <div class="mt-4 flex justify-end">
                   <PageComponent />
+                </div>
+              ),
+              footerLeft: () => (
+                <div class="mt-4 flex items-center gap-3">
+                  <NSelect
+                    v-model:value={batchActionRef.value}
+                    options={batchActionOptions}
+                    style={{ width: "120px" }}
+                    disabled={checkedRowKeysRef.value.length === 0}
+                    size="small"
+                  />
+                  <NButton
+                    size="small"
+                    type="primary"
+                    disabled={checkedRowKeysRef.value.length === 0}
+                    onClick={handleBatchAction}
+                  >
+                    批量操作
+                  </NButton>
+                  <span class="text-gray-500">
+                    已选中 {checkedRowKeysRef.value.length} 项
+                  </span>
                 </div>
               ),
             }}

--- a/frontend/apps/allin-ssl/src/views/privateCaCert/types.d.ts
+++ b/frontend/apps/allin-ssl/src/views/privateCaCert/types.d.ts
@@ -14,8 +14,11 @@ export interface CertItem {
 	algorithm: string;
 	not_before: string;
 	not_after: string;
+	/** normal | revoked | expired(前端推导) */
 	status: string;
 	ca_cn: string;
+	revoke_reason?: string;
+	revoked_at?: string;
 }
 
 // 表格查询参数

--- a/frontend/apps/allin-ssl/src/views/privateCaCert/useController.tsx
+++ b/frontend/apps/allin-ssl/src/views/privateCaCert/useController.tsx
@@ -23,9 +23,22 @@ import type {
 	KeyLengthOption,
 	ValidityUnit
 } from './types';
-import { createLeafCert, deleteLeafCert } from '@/api/ca';
-import type { CreateLeafCertParams, DeleteLeafCertParams } from '@/types/ca';
+import { createLeafCert, deleteLeafCert, revokeLeafCert } from '@/api/ca';
+import type { CreateLeafCertParams, DeleteLeafCertParams, RevokeLeafCertParams } from '@/types/ca';
 import type { GetLeafCertListParams } from '@/types/ca';
+
+
+const REVOKE_REASON_OPTIONS = [
+  { label: '未指定 (unspecified)', value: 0 },
+  { label: '密钥泄露 (keyCompromise)', value: 1 },
+  { label: 'CA 泄露 (cACompromise)', value: 2 },
+  { label: '从属关系变更 (affiliationChanged)', value: 3 },
+  { label: '被取代 (superseded)', value: 4 },
+  { label: '停止运营 (cessationOfOperation)', value: 5 },
+  { label: '证书挂起 (certificateHold)', value: 6 },
+  { label: '权限撤销 (privilegeWithdrawn)', value: 9 },
+  { label: 'AA 泄露 (aACompromise)', value: 10 },
+]
 
 const { handleError } = useError();
 
@@ -40,8 +53,20 @@ export const useController = () => {
 
   const message = useMessage();
 
+  const checkedRowKeysRef = ref<(string | number)[]>([]);
+  const batchActionRef = ref<string>("delete");
+
+  const handleCheck = (rowKeys: (string | number)[]) => {
+    checkedRowKeysRef.value = rowKeys;
+  };
+
+
   // 获取状态标签类型和文本
-  const getStatusInfo = (notAfter: string) => {
+  const getStatusInfo = (cert: CertItem) => {
+    if (cert.status === "revoked") {
+      return { type: "error" as const, text: "已吊销" };
+    }
+
     const calculateRemainingDays = (expiryDate: string) => {
       const expiry = new Date(expiryDate);
       const now = new Date();
@@ -50,7 +75,7 @@ export const useController = () => {
       return diffDays;
     };
 
-    const remainingDays = calculateRemainingDays(notAfter);
+    const remainingDays = calculateRemainingDays(cert.not_after);
 
     if (remainingDays > 30) {
       return { type: "success" as const, text: "正常" };
@@ -65,6 +90,9 @@ export const useController = () => {
 
   // 创建表格列
   const createColumns = (): DataTableColumns<CertItem> => [
+    {
+      type: "selection",
+    },
     {
       title: "名称",
       key: "cn",
@@ -181,7 +209,7 @@ export const useController = () => {
       key: "status",
       width: 100,
       render: (row: CertItem) => {
-        const statusInfo = getStatusInfo(row.not_after);
+        const statusInfo = getStatusInfo(row);
         return (
           <NTag type={statusInfo.type} size="small">
             {statusInfo.text}
@@ -199,7 +227,7 @@ export const useController = () => {
       key: "actions",
       fixed: "right" as const,
       align: "right",
-      width: 200,
+      width: 260,
       render: (row: CertItem) => (
         <NFlex justify="end">
           <NButton
@@ -212,6 +240,18 @@ export const useController = () => {
           >
             下载
           </NButton>
+          {row.status !== "revoked" && (
+            <NButton
+              size="tiny"
+              strong
+              secondary
+              type="warning"
+              class="table-action-btn"
+              onClick={() => handleRevoke(row)}
+            >
+              吊销
+            </NButton>
+          )}
           <NButton
             size="tiny"
             strong
@@ -254,7 +294,7 @@ export const useController = () => {
 
   // 获取行样式类名
   const getRowClassName = (row: CertItem): string => {
-    const statusInfo = getStatusInfo(row.not_after);
+    const statusInfo = getStatusInfo(row);
     if (statusInfo.type === "error") return "bg-red-500/10";
     if (statusInfo.type === "warning") return "bg-orange-500/10";
     return "";
@@ -270,6 +310,62 @@ export const useController = () => {
     } catch (error) {
       handleError(error);
     }
+  };
+
+  // 吊销证书
+  const handleRevoke = async (cert: CertItem) => {
+    if (cert.status === "revoked") {
+      useMessage().warning("证书已吊销");
+      return;
+    }
+    const reasonRef = ref<number>(0);
+    const { open: openLoad, close } = useLoadingMask({
+      text: "正在吊销，请稍后...",
+      zIndex: 3000,
+    });
+    useDialog({
+      title: "确认吊销",
+      content: () => (
+        <div class="flex flex-col gap-3">
+          <div>确定要吊销证书 "{cert.cn}" 吗？吊销后证书将不可再被工作流复用，此操作不可恢复。</div>
+          <div>
+            <div class="mb-1 text-sm text-gray-500">吊销原因</div>
+            <NSelect
+              value={reasonRef.value}
+              options={REVOKE_REASON_OPTIONS}
+              onUpdateValue={(v: number) => {
+                reasonRef.value = v;
+              }}
+            />
+          </div>
+        </div>
+      ),
+      onPositiveClick: async () => {
+        try {
+          openLoad();
+          const {
+            message,
+            fetch: revokeFetch,
+            data,
+          } = revokeLeafCert({
+            id: cert.id.toString(),
+            reason: reasonRef.value,
+          } as RevokeLeafCertParams);
+          message.value = true;
+          await revokeFetch();
+          if (data.value.status) {
+            useMessage().success(data.value.message || "吊销成功");
+            await fetch();
+          } else {
+            useMessage().error(data.value?.message || "吊销失败");
+          }
+        } catch (error) {
+          handleError(error);
+        } finally {
+          close();
+        }
+      },
+    });
   };
 
   // 删除证书
@@ -309,7 +405,104 @@ export const useController = () => {
   };
 
   // 打开签发证书模态框
-  const openCreateLeafCertModal = async () => {
+  
+  // 批量操作：删除 / 吊销
+  const handleBatchAction = async () => {
+    if (checkedRowKeysRef.value.length === 0) {
+      return;
+    }
+    if (batchActionRef.value === "delete") {
+      const { open: openLoad, close } = useLoadingMask({
+        text: "正在批量删除，请稍后...",
+        zIndex: 3000,
+      });
+      useDialog({
+        title: "批量删除证书",
+        content: `确定要删除选中的 ${checkedRowKeysRef.value.length} 个证书吗？此操作不可恢复。`,
+        onPositiveClick: async () => {
+          try {
+            openLoad();
+            const {
+              message,
+              fetch: deleteFetch,
+              data,
+            } = deleteLeafCert({
+              id: checkedRowKeysRef.value.join(","),
+            } as DeleteLeafCertParams);
+            message.value = true;
+            await deleteFetch();
+            if (data.value?.status) {
+              useMessage().success(data.value.message || "批量删除成功");
+              checkedRowKeysRef.value = [];
+              await fetch();
+            } else {
+              useMessage().error(data.value?.message || "批量删除失败");
+            }
+          } catch (error) {
+            handleError(error);
+          } finally {
+            close();
+          }
+        },
+      });
+      return;
+    }
+    if (batchActionRef.value === "revoke") {
+      const reasonRef = ref<number>(0);
+      const { open: openLoad, close } = useLoadingMask({
+        text: "正在批量吊销，请稍后...",
+        zIndex: 3000,
+      });
+      useDialog({
+        title: "批量吊销证书",
+        content: () => (
+          <div class="flex flex-col gap-3">
+            <div>
+              确定要吊销选中的 {checkedRowKeysRef.value.length} 个证书吗？已吊销的会自动跳过，此操作不可恢复。
+            </div>
+            <div>
+              <div class="mb-1 text-sm text-gray-500">吊销原因</div>
+              <NSelect
+                value={reasonRef.value}
+                options={REVOKE_REASON_OPTIONS}
+                onUpdateValue={(v: number) => {
+                  reasonRef.value = v;
+                }}
+              />
+            </div>
+          </div>
+        ),
+        onPositiveClick: async () => {
+          try {
+            openLoad();
+            const {
+              message,
+              fetch: revokeFetch,
+              data,
+            } = revokeLeafCert({
+              id: checkedRowKeysRef.value.join(","),
+              reason: reasonRef.value,
+            } as RevokeLeafCertParams);
+            message.value = true;
+            await revokeFetch();
+            if (data.value?.status) {
+              useMessage().success(data.value.message || "批量吊销成功");
+              checkedRowKeysRef.value = [];
+              await fetch();
+            } else {
+              useMessage().error(data.value?.message || "批量吊销失败");
+            }
+          } catch (error) {
+            handleError(error);
+          } finally {
+            close();
+          }
+        },
+      });
+    }
+  };
+
+const openCreateLeafCertModal = async () => {
     try {
       await getIntermediateCaList();
       useModal({
@@ -341,10 +534,15 @@ export const useController = () => {
     SearchComponent,
     getRowClassName,
     handleDownload,
+    handleRevoke,
     handleDelete,
     openCreateLeafCertModal,
     fetch,
     handleCaIdChange,
+    checkedRowKeysRef,
+    handleCheck,
+    batchActionRef,
+    handleBatchAction,
   };
 };
 
@@ -353,7 +551,8 @@ export const useController = () => {
  * @returns {Object} 返回签发证书表单控制器对象
  */
 export const useCreateLeafCertController = (list: IntermediateCa[]) => {
-  const { handleError } = useError();
+  
+const { handleError } = useError();
   const { confirm } = useModalHooks();
   const { useFormInput, useFormSelect, useFormCustom } = useFormHooks();
 

--- a/frontend/apps/allin-ssl/src/views/privateCaManage/useController.tsx
+++ b/frontend/apps/allin-ssl/src/views/privateCaManage/useController.tsx
@@ -165,6 +165,16 @@ export const useController = () => {
 					>
 						下载
 					</NButton>
+						<NButton
+							class="table-action-btn"
+							size="tiny"
+							strong
+							secondary
+							type="info"
+							onClick={() => handleDownloadCrl(row)}
+						>
+							CRL
+						</NButton>
 					<NButton
 						class="table-action-btn-danger"
 						size="tiny"
@@ -306,7 +316,20 @@ export const useController = () => {
 	};
 
 	// 删除CA事件
-	const handleDelete = async (row: PrivateCaItem) => {
+	
+	// 下载 CRL
+	const handleDownloadCrl = (row: PrivateCaItem) => {
+		try {
+			const link = document.createElement("a");
+			link.href = `/v1/private_ca/download_crl?id=${row.id.toString()}`;
+			link.target = "_blank";
+			link.click();
+		} catch (error: any) {
+			handleError(error);
+		}
+	};
+
+const handleDelete = async (row: PrivateCaItem) => {
 		const { open: openLoad, close: close } = useLoadingMask({ text: '正在删除CA，请稍后...', zIndex: 3000 });
 		useDialog({
 			title: "删除CA",

--- a/frontend/apps/allin-ssl/src/views/settings/useController.tsx
+++ b/frontend/apps/allin-ssl/src/views/settings/useController.tsx
@@ -484,6 +484,9 @@ export const useGeneralSettingsController = () => {
         showPasswordOn: "click",
       }),
       useFormInput("插件目录", "plugin_path"),
+	      useFormInput("公网基址 (CRL/OCSP)", "public_base_url", {
+	        placeholder: "https://ca.example.com",
+	      }),
       useFormSwitch("启用SSL", "https", {
         checkedValue: "1",
         uncheckedValue: "0",


### PR DESCRIPTION
## 变更说明

基于分支 **1.1.3**，仅 1 个功能提交，包含：

### 核心
- ACME 公网证书吊销（向 CA 发送 ACME revoke）
- 私有 CA 叶子证书吊销
- 证书管理 / 私有证书管理：勾选批量删除、批量吊销
- 吊销原因可选（RFC 5280）

### 配套
- 私有 CA CRL 生成与下载
- 私有 CA OCSP 应答（公开接口）
- 系统设置：公网基址 `public_base_url`（用于 CDP/OCSP URL）
- 历史 ACME 证书账户信息回填（便于旧证书吊销）

## 测试建议

1. 证书管理：单条/批量吊销、批量删除
2. 私有证书管理：单条/批量吊销、批量删除
3. 私有 CA 管理：下载 CRL
4. 设置中配置公网基址后，新签发叶子证书含 CDP/OCSP
5. 启动后或调用回填接口，旧证书可补齐 acme_email/acme_ca
