### PR TITLE
【修复】Star History 图表无法显示

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ This project is licensed under the [AGPL-3.0 license](./LICENSE).
 
 ## 🌟 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=allinssl/allinssl&type=Date)](https://www.star-history.com/#allinssl/allinssl&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=allinssl/allinssl&type=Date)](https://star-history.dera.page/#allinssl/allinssl&Date)
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -283,7 +283,7 @@ allinssl 17: 卸载ALLinSSL 🗑️
 
 ## 🌟Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=allinssl/allinssl&type=Date)](https://www.star-history.com/#allinssl/allinssl&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=allinssl/allinssl&type=Date)](https://star-history.dera.page/#allinssl/allinssl&Date)
 
 ---
 


### PR DESCRIPTION
目前 README 中的 Star History 图表已经失效，无法正常展示项目的星标趋势。这是因为上游数据源受到 GitHub API 限制所致。

本次修改将图表切换到可用的数据源，恢复图表的正常展示，避免给访问者留下项目停止维护的错觉。希望维护者能尽快合并此修复，感谢！